### PR TITLE
Port all target geometry

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -70,6 +70,18 @@ function run_all {
 	run_geometry_gemc projects/clas12/targets targets.py target_lh2e.jcard
 	run_geometry_gemc projects/clas12/targets targets.py target_ld2.jcard
 	run_geometry_gemc projects/clas12/targets targets.py target_pol_targ.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_bonus.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_pb_test.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_nd3.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_sn118.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_pb208.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_cu63.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_al27.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_hdice.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_longitudinal.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_transverse.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_apollo_nh3.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_apollo_nd3.jcard
 }
 
 function run_targets {
@@ -78,6 +90,19 @@ function run_targets {
 	run_geometry_gemc projects/clas12/targets targets.py target_lh2e.jcard
 	run_geometry_gemc projects/clas12/targets targets.py target_ld2.jcard
 	run_geometry_gemc projects/clas12/targets targets.py target_pol_targ.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_bonus.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_pb_test.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_nd3.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_sn118.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_pb208.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_cu63.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_al27.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_hdice.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_longitudinal.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_transverse.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_apollo_nh3.jcard
+	run_geometry_gemc projects/clas12/targets targets.py target_apollo_nd3.jcard
+
 }
 
 echo

--- a/gemc_api_geometry.py
+++ b/gemc_api_geometry.py
@@ -80,16 +80,6 @@ NOTAPPLICABLE = 'na'        # for optionals fields
 DEFAULTMOTHER = 'root'
 DEFAULTCOLOR  = '778899'
 
-_MAP_MATERIAL_TO_G4_EQUIV = {
-	"LD2": "G4_lH2",
-	"lHeCoolant": "G4_WATER",
-	"NH3target": "G4_WATER",
-	"AmmoniaCellWalls": "G4_WATER",
-	"ND3target": "G4_WATER",
-	"ShimCoil" : "G4_WATER",
-}
-
-
 # GVolume class definition
 class GVolume():
 	def __init__(self, name):

--- a/gemc_api_geometry.py
+++ b/gemc_api_geometry.py
@@ -175,6 +175,8 @@ class GVolume():
 
 				dn.write(lstr)
 
+	# @mariakzurek: in polycone the zplane and radious order are swapped w.r.t. gmc2 implementation
+	# is that how it should be?  
 	def makeG4Polycone(self, phiStart, phiTotal, nplanes, zplane, iradius, oradius, lunit = 'mm'):
 		self.solid = 'G4Polycone'
 		mylengths  = ' '

--- a/gemc_api_materials.py
+++ b/gemc_api_materials.py
@@ -73,7 +73,7 @@
 #			E = h * nu		   where h is Plank's constant
 #			A handy relation for estimating is that h*c ~ 197 eV*nm
 
-import sys
+import sys, math
 
 # for mandatory fields. Used in function checkValidity
 WILLBESETSTRING     = 'notSetYet'
@@ -139,7 +139,7 @@ class GMaterial():
 			if self.totComposition <= 1:
 				sys.exit(' Error: chemical formula has total composition less or equal 1  for material: ' + str(self.name) )
 		if self.compType == ISFRACTIONAL:
-			if self.totComposition != 1:
+			if not math.isclose(self.totComposition, 1, rel_tol=1e-6):
 				sys.exit(' Error: fractional masses do not add to 1 for material: ' + str(self.name) )
 
 	def publish(self, configuration):

--- a/projects/clas12/targets/geometry.py
+++ b/projects/clas12/targets/geometry.py
@@ -565,7 +565,7 @@ def build_geometry_bonus(configuration):
 
 	for builder in [
 		build_bonus_root_volume,
-		# build_bonus_target_gas_volume,
+		build_bonus_target_gas_volume,
 		build_bonus_target_wall,
 		build_bonus_target_downstream_aluminum_end_cap_r_ing,
 		build_bonus_target_downstream_end_cap_r_ing,

--- a/projects/clas12/targets/geometry.py
+++ b/projects/clas12/targets/geometry.py
@@ -1,6 +1,5 @@
 from gemc_api_geometry import *
 
-
 def build_geometry_lhydrogen(configuration):
 
 	variation = configuration.variation
@@ -77,11 +76,11 @@ def build_geometry_c12(configuration):
 			z_center,
 			color="aa0000",
 		):
-			r_out = 5
+			r_out = 5.0
 			half_length = 0.86
-			r_in = 0.
-			phi_start = 0.
-			phi_total = 360
+			r_in = 0.0
+			phi_start = 0.0
+			phi_total = 360.0
 
 			gvolume = GVolume(f"{name_prefix}NuclearTargFoil")
 			gvolume.mother = "target"
@@ -125,392 +124,608 @@ def build_geometry_c12(configuration):
 		volume.publish(configuration)
 
 
-def _make_full_tubs(gvolume, r_in, r_out, half_length):
-	gvolume.makeG4Tubs(r_in, r_out, half_length, 0, 360)
+def _make_full_tube(gvolume, r_in, r_out, half_length):
+	gvolume.makeG4Tubs(r_in, r_out, half_length, 0.0, 360.0)
 
 
 def build_geometry_pol_targ(configuration):
-		# vacuum container
-		r_in = 0
-		r_out = 44
-		half_length = 130
+	# vacuum container
+	r_in = 0
+	r_out = 44
+	half_length = 130
+	gvolume = GVolume("PolTarg")
+	gvolume.description = "PolTarg Region"
+	gvolume.color = "aaaaaa9"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_Galactic"
+	gvolume.publish(configuration)
+	
+	# LHe fill between targets
+	z_center = 0  # center location of target along beam axis
+	r_in = 0
+	r_out = 10  # radius in mm
+	half_length = 14.97  # half length along beam axis
+	gvolume = GVolume("LHeVoidFill")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "LHe between target cells"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "0000ff"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "lHeCoolant"
+	gvolume.publish(configuration)
+	
+	# NH3Targ
+	z_center = -25  # center location of target along beam axis
+	r_in = 0
+	r_out = 10  # radius in mm
+	half_length = 9.96  # half length along beam axis
+	gvolume = GVolume("NH3Targ")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Upstream NH3 target cell"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "f000f0"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "NH3target"
+	gvolume.publish(configuration)
 
-		gvolume = GVolume("PolTarg")
-		gvolume.mother = "root"
-		gvolume.description = "PolTarg Region"
-		gvolume.color = "aaaaaa9"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "G4_Galactic"
-		gvolume.publish(configuration)
-		
-		# LHe fill between targets
-		z_center = 0  # center location of target along beam axis
-		r_in = 0
-		r_out = 10  # radius in mm
-		half_length = 14.97  # half length along beam axis
-		gvolume = GVolume("LHeVoidFill")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "LHe between target cells"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "0000ff"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "lHeCoolant"
-		gvolume.publish(configuration)
-		
-		# NH3Targ
-		z_center = -25  # center location of target along beam axis
-		r_in = 0
-		r_out = 10  # radius in mm
-		half_length = 9.96  # half length along beam axis
-		gvolume = GVolume("NH3Targ")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Upstream NH3 target cell"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "f000f0"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "NH3target"
-		gvolume.publish(configuration)
+	# NH3Targ Cup
+	z_center = -25
+	r_in = 10.0001  # radius in mm
+	r_out = 10.03  # radius in mm
+	half_length = 9.75  # half length along beam axis
+	gvolume = GVolume("NH3Cup")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Upstream NH3 Target cup"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "ffffff"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "AmmoniaCellWalls"
+	gvolume.publish(configuration)
 
-		# NH3Targ Cup
-		z_center = -25
-		r_in = 10.0001  # radius in mm
-		r_out = 10.03  # radius in mm
-		half_length = 9.75  # half length along beam axis
-		gvolume = GVolume("NH3Cup")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Upstream NH3 Target cup"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "ffffff"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "AmmoniaCellWalls"
-		gvolume.publish(configuration)
+	# NH3Targ Cup Down Stream Ring
+	z_center = -35
+	r_in = 10.0001  # radius in mm
+	r_out = 11.43  # radius in mm
+	half_length = 0.25  # half length along beam axis
+	gvolume = GVolume("NH3CupDSRing")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Upstream NH3 Target cup downstream Ring"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "ffffff"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "AmmoniaCellWalls"
+	gvolume.publish(configuration)
 
-		# NH3Targ Cup Down Stream Ring
-		z_center = -35
-		r_in = 10.0001  # radius in mm
-		r_out = 11.43  # radius in mm
-		half_length = 0.25  # half length along beam axis
-		gvolume = GVolume("NH3CupDSRing")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Upstream NH3 Target cup downstream Ring"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "ffffff"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "AmmoniaCellWalls"
-		gvolume.publish(configuration)
+	# NH3Targ Cup UP Stream Ring
+	z_center = -15
+	r_in = 10.0001  # radius in mm
+	r_out = 12.7  # radius in mm
+	half_length = 0.25  # half length along beam axis
+	gvolume = GVolume("NH3CupUSRing")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Upstream NH3 Target cup Upstream Ring"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "ffffff"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "AmmoniaCellWalls"
+	gvolume.publish(configuration)
 
-		# NH3Targ Cup UP Stream Ring
-		z_center = -15
-		r_in = 10.0001  # radius in mm
-		r_out = 12.7  # radius in mm
-		half_length = 0.25  # half length along beam axis
-		gvolume = GVolume("NH3CupUSRing")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Upstream NH3 Target cup Upstream Ring"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "ffffff"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "AmmoniaCellWalls"
-		gvolume.publish(configuration)
+	# NH3Targ Cup Window Frame
+	z_center = -35
+	r_in = 11.44  # radius in mm
+	r_out = 12.7  # radius in mm
+	half_length = 1.5875  # half length along beam axis
+	gvolume = GVolume("NH3CupWindowFrame_20")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Upstream NH3 Target cup Window frame"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "ffffff"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "AmmoniaCellWalls"
+	gvolume.publish(configuration)
 
-		# NH3Targ Cup Window Frame
-		z_center = -35
-		r_in = 11.44  # radius in mm
-		r_out = 12.7  # radius in mm
-		half_length = 1.5875  # half length along beam axis
-		gvolume = GVolume("NH3CupWindowFrame_20")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Upstream NH3 Target cup Window frame"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "ffffff"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "AmmoniaCellWalls"
-		gvolume.publish(configuration)
+	# NH3Targ Cup Up Stream Window
+	z_center = -35
+	r_in = 0  # radius in mm
+	r_out = 10  # radius in mm
+	half_length = 0.025  # half length along beam axis	
+	gvolume = GVolume("NH3CupUSWindow_20")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Upstream NH3 Target cup Upstream Window"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "aaaaaa"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_Al"
+	gvolume.publish(configuration)
 
-		# NH3Targ Cup Up Stream Window
-		z_center = -35
-		r_in = 0  # radius in mm
-		r_out = 10  # radius in mm
-		half_length = 0.025  # half length along beam axis		
-		gvolume = GVolume("NH3CupUSWindow_20")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Upstream NH3 Target cup Upstream Window"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "aaaaaa"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "G4_Al"
-		gvolume.publish(configuration)
+	# NH3Targ Cup Downstream Stream Window
+	z_center = -15
+	r_in = 0  # radius in mm
+	r_out = 10  # radius in mm
+	half_length = 0.025  # half length along beam axis
+	gvolume = GVolume("NH3CupDSWindow")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Upstream NH3 Target cup Downstream Window"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "aaaaaa"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_Al"
+	gvolume.publish(configuration)
 
-		# NH3Targ Cup Downstream Stream Window
-		z_center = -15
-		r_in = 0  # radius in mm
-		r_out = 10  # radius in mm
-		half_length = 0.025  # half length along beam axis
-		gvolume = GVolume("NH3CupDSWindow")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Upstream NH3 Target cup Downstream Window"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "aaaaaa"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "G4_Al"
-		gvolume.publish(configuration)
+	# NH3Targ
+	z_center = 25  # center location of target along beam axis
+	r_in = 0
+	r_out = 10  # radius in mm
+	half_length = 9.96  # half length along beam axis	
+	gvolume = GVolume("ND3Targ")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Downstream ND3 target cell"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "f000f0"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "ND3target"
+	gvolume.publish(configuration)
 
-		# NH3Targ
-		z_center = 25  # center location of target along beam axis
-		r_in = 0
-		r_out = 10  # radius in mm
-		half_length = 9.96  # half length along beam axis	
-		gvolume = GVolume("ND3Targ")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Downstream ND3 target cell"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "f000f0"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "ND3target"
-		gvolume.publish(configuration)
+	# NH3Targ Cup
+	z_center = 25
+	r_in = 10.0001  # radius in mm
+	r_out = 10.03  # radius in mm
+	half_length = 9.75  # half length along beam axis
+	gvolume = GVolume("ND3Cup")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Downstream ND3 Target cup"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "ffffff"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "AmmoniaCellWalls"
+	gvolume.publish(configuration)
 
-		# NH3Targ Cup
-		z_center = 25
-		r_in = 10.0001  # radius in mm
-		r_out = 10.03  # radius in mm
-		half_length = 9.75  # half length along beam axis
-		gvolume = GVolume("ND3Cup")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Downstream ND3 Target cup"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "ffffff"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "AmmoniaCellWalls"
-		gvolume.publish(configuration)
+	# ND3Targ Cup Down Stream Ring
+	z_center = 35
+	r_in = 10.0001  # radius in mm
+	r_out = 11.43  # radius in mm
+	half_length = 0.25  # half length along beam axis
+	gvolume = GVolume("ND3CupDSRing")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Downstream ND3 Target cup downstream Ring"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "ffffff"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "AmmoniaCellWalls"
+	gvolume.publish(configuration)
 
-		# ND3Targ Cup Down Stream Ring
-		z_center = 35
-		r_in = 10.0001  # radius in mm
-		r_out = 11.43  # radius in mm
-		half_length = 0.25  # half length along beam axis
-		gvolume = GVolume("ND3CupDSRing")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Downstream ND3 Target cup downstream Ring"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "ffffff"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "AmmoniaCellWalls"
-		gvolume.publish(configuration)
+	# ND3Targ Cup UP Stream Ring
+	z_center = 15
+	r_in = 10.0001  # radius in mm
+	r_out = 11.43  # radius in mm
+	half_length = 0.25  # half length along beam axis
+	gvolume = GVolume("ND3CupUSRing")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Downstrem ND3 Target cup Upstream Ring"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "ffffff"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "AmmoniaCellWalls"
+	gvolume.publish(configuration)
 
-		# ND3Targ Cup UP Stream Ring
-		z_center = 15
-		r_in = 10.0001  # radius in mm
-		r_out = 11.43  # radius in mm
-		half_length = 0.25  # half length along beam axis
-		gvolume = GVolume("ND3CupUSRing")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Downstrem ND3 Target cup Upstream Ring"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "ffffff"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "AmmoniaCellWalls"
-		gvolume.publish(configuration)
+	# ND3Targ Cup Window Frame
+	z_center = 15
+	r_in = 11.44  # radius in mm
+	r_out = 12.7  # radius in mm
+	half_length = 1.5875  # half length along beam axis
+	gvolume = GVolume("ND3CupWindowFrame_20")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Upstream NH3 Target cup Window frame"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "ffffff"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "AmmoniaCellWalls"
+	gvolume.publish(configuration)
 
-		# ND3Targ Cup Window Frame
-		z_center = 15
-		r_in = 11.44  # radius in mm
-		r_out = 12.7  # radius in mm
-		half_length = 1.5875  # half length along beam axis
-		gvolume = GVolume("ND3CupWindowFrame_20")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Upstream NH3 Target cup Window frame"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "ffffff"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "AmmoniaCellWalls"
-		gvolume.publish(configuration)
+	# ND3Targ Cup Up Stream Window
+	z_center = 35
+	r_in = 0.0  # radius in mm
+	r_out = 10.0  # radius in mm
+	half_length = 0.025  # half length along beam axis	
+	gvolume = GVolume("ND3CupUSWindow_20")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Downstream ND3 Target cup Upstream Window"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "aaaaaa"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_Al"
+	gvolume.publish(configuration)
 
-		# ND3Targ Cup Up Stream Window
-		z_center = 35
-		r_in = 0.0  # radius in mm
-		r_out = 10.0  # radius in mm
-		half_length = 0.025  # half length along beam axis	
-		gvolume = GVolume("ND3CupUSWindow_20")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Downstream ND3 Target cup Upstream Window"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "aaaaaa"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "G4_Al"
-		gvolume.publish(configuration)
+	# ND3Targ Cup Downstream Stream Window
+	z_center = 15
+	r_in = 0.0  # radius in mm
+	r_out = 10.0  # radius in mm
+	half_length = 0.025  # half length along beam axis	
+	gvolume = GVolume("ND3CupDSWindow")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Downstream ND3 Target cup Downstream Window"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "aaaaaa"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_Al"
+	gvolume.publish(configuration)
 
-		# ND3Targ Cup Downstream Stream Window
-		z_center = 15
-		r_in = 0.0  # radius in mm
-		r_out = 10.0  # radius in mm
-		half_length = 0.025  # half length along beam axis	
-		gvolume = GVolume("ND3CupDSWindow")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Downstream ND3 Target cup Downstream Window"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "aaaaaa"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "G4_Al"
-		gvolume.publish(configuration)
+	# Insert Bath Entrance window part 7 a
+	z_center = -37.395
+	r_in = 0.0  # radius in mm
+	r_out = 11.5  # radius in mm
+	half_length = 0.605  # half length along beam axis
+	gvolume = GVolume("InsertBathEntranceWindow_7a")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Insert Bath Entrence window part 7 a"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "aaaaaa"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_Al"
+	gvolume.publish(configuration)
 
-		# Insert Bath Entrance window part 7 a
-		z_center = -37.395
-		r_in = 0.0  # radius in mm
-		r_out = 11.5  # radius in mm
-		half_length = 0.605  # half length along beam axis
-		gvolume = GVolume("InsertBathEntranceWindow_7a")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Insert Bath Entrence window part 7 a"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "aaaaaa"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "G4_Al"
-		gvolume.publish(configuration)
+	# Insert Bath Entrance window part 7 b
+	z_center = -68.2
+	r_in = 11.0  # radius in mm
+	r_out = 11.5  # radius in mm
+	half_length = 30.1  # half length along beam axis
+	gvolume = GVolume("InsertBathEntranceWindow_7b")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Insert Bath Entrence window part 7 b"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "aaaaaa"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_Al"
+	gvolume.publish(configuration)
 
-		# Insert Bath Entrance window part 7 b
-		z_center = -68.2
-		r_in = 11.0  # radius in mm
-		r_out = 11.5  # radius in mm
-		half_length = 30.1  # half length along beam axis
-		gvolume = GVolume("InsertBathEntranceWindow_7b")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Insert Bath Entrence window part 7 b"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "aaaaaa"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "G4_Al"
-		gvolume.publish(configuration)
+	# Insert Bath Entrance window part 7 c
+	z_center = -98.4
+	r_in = 11.5001  # radius in mm
+	r_out = 14.4  # radius in mm
+	half_length = 3.17  # half length along beam axis
+	gvolume = GVolume("InsertBathEntranceWindow_7c")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Insert Bath Entrence window part 7 c"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "aaaaaa"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_Al"
+	gvolume.publish(configuration)
 
-		# Insert Bath Entrance window part 7 c
-		z_center = -98.4
-		r_in = 11.5001  # radius in mm
-		r_out = 14.4  # radius in mm
-		half_length = 3.17  # half length along beam axis
-		gvolume = GVolume("InsertBathEntranceWindow_7c")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Insert Bath Entrence window part 7 c"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "aaaaaa"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "G4_Al"
-		gvolume.publish(configuration)
+	# Insert Bath Entrance window part 7 d
+	z_center = -102.23
+	r_in = 11.0  # radius in mm
+	r_out = 14.96  # radius in mm
+	half_length = 0.66  # half length along beam axis
+	gvolume = GVolume("InsertBathEntranceWindow_7d")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Insert Bath Entrence window part 7 d"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "aaaaaa"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_Al"
+	gvolume.publish(configuration)
+	
+	# Shim Coil Carrier
+	z_center = -19.3
+	r_in = 28.8  # radius in mm
+	r_out = 29.3  # radius in mm
+	half_length = 80.95  # half length along beam axis	
+	gvolume = GVolume("ShimCoilCarrier")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Shim Coil Carrier"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "aaaaaa"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_Al"
+	gvolume.publish(configuration)
 
-		# Insert Bath Entrance window part 7 d
-		z_center = -102.23
-		r_in = 11.0  # radius in mm
-		r_out = 14.96  # radius in mm
-		half_length = 0.66  # half length along beam axis
-		gvolume = GVolume("InsertBathEntranceWindow_7d")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Insert Bath Entrence window part 7 d"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "aaaaaa"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "G4_Al"
-		gvolume.publish(configuration)
-		
-		# Shim Coil Carrier
-		z_center = -19.3
-		r_in = 28.8  # radius in mm
-		r_out = 29.3  # radius in mm
-		half_length = 80.95  # half length along beam axis	
-		gvolume = GVolume("ShimCoilCarrier")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Shim Coil Carrier"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "aaaaaa"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "G4_Al"
-		gvolume.publish(configuration)
+	# Shim Up Up stream Coil
+	z_center = 43.5
+	r_in = 29.3  # radius in mm
+	r_out = 30.0  # radius in mm
+	half_length = 6.0  # half length along beam axis
+	gvolume = GVolume("ShimUpUpS")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Shim Coil Up Up stream Coil"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "a00000"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "ShimCoil"
+	gvolume.publish(configuration)
 
-		# Shim Up Up stream Coil
-		z_center = 43.5
-		r_in = 29.3  # radius in mm
-		r_out = 30.0  # radius in mm
-		half_length = 6.0  # half length along beam axis
-		gvolume = GVolume("ShimUpUpS")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Shim Coil Up Up stream Coil"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "a00000"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "ShimCoil"
-		gvolume.publish(configuration)
+	# Shim Up stream Coil
+	z_center = 8.5
+	r_in = 29.3  # radius in mm
+	r_out = 30.0  # radius in mm
+	half_length = 6.0  # half length along beam axis
+	gvolume = GVolume("ShimUpS")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Shim Coil Up stream"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "a00000"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "ShimCoil"
+	gvolume.publish(configuration)
 
-		# Shim Up stream Coil
-		z_center = 8.5
-		r_in = 29.3  # radius in mm
-		r_out = 30.0  # radius in mm
-		half_length = 6.0  # half length along beam axis
-		gvolume = GVolume("ShimUpS")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Shim Coil Up stream"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "a00000"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "ShimCoil"
-		gvolume.publish(configuration)
+	# Shim Down stream Coil
+	z_center = -8.5
+	r_in = 29.3  # radius in mm
+	r_out = 30.0  # radius in mm
+	half_length = 6.0  # half length along beam axis
+	gvolume = GVolume("ShimDownS")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Shim Coil Down stream"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "a00000"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "ShimCoil"
+	gvolume.publish(configuration)
 
-		# Shim Down stream Coil
-		z_center = -8.5
-		r_in = 29.3  # radius in mm
-		r_out = 30.0  # radius in mm
-		half_length = 6.0  # half length along beam axis
-		gvolume = GVolume("ShimDownS")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Shim Coil Down stream"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "a00000"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "ShimCoil"
-		gvolume.publish(configuration)
+	# Shim Down Down stream Coil
+	z_center = -43.5
+	r_in = 29.3  # radius in mm
+	r_out = 30.0  # radius in mm
+	half_length = 6.0  # half length along beam axis
+	gvolume = GVolume("ShimDownDownS")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "Shim Coil Down Down stream"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "a00000"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "ShimCoil"
+	gvolume.publish(configuration)
+	
+	# Heat Shield tube
+	z_center = -34.3
+	r_in = 40.3  # radius in mm
+	r_out = 41.3  # radius in mm
+	half_length = 83.85  # half length along beam axis
+	gvolume = GVolume("HeatShieldTube")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "PolTarg Heat Shield Tube"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "aaaaaa"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_Al"
+	gvolume.publish(configuration)
 
-		# Shim Down Down stream Coil
-		z_center = -43.5
-		r_in = 29.3  # radius in mm
-		r_out = 30.0  # radius in mm
-		half_length = 6.0  # half length along beam axis
-		gvolume = GVolume("ShimDownDownS")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "Shim Coil Down Down stream"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "a00000"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "ShimCoil"
-		gvolume.publish(configuration)
-		
-		# Heat Shield tube
-		z_center = -34.3
-		r_in = 40.3  # radius in mm
-		r_out = 41.3  # radius in mm
-		half_length = 83.85  # half length along beam axis
-		gvolume = GVolume("HeatShieldTube")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "PolTarg Heat Shield Tube"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "aaaaaa"
-		_make_full_tubs(gvolume, r_in, r_out, half_length)
-		gvolume.material = "G4_Al"
-		gvolume.publish(configuration)
+	# Heat Shield Half Sphere
+	z_center = 49.55
+	r_in = 40.3  # radius in mm
+	r_out = 41.3  # radius in mm
+	gvolume = GVolume("HeatShieldSphere")
+	gvolume.mother = "PolTarg"
+	gvolume.description = "PolTarg Heat Shield Exit window Shere"
+	gvolume.setPosition(0,0,z_center)
+	gvolume.color = "aaaaaa"
+	gvolume.makeG4Sphere(r_in, r_out, 0, 360, 0, 90)
+	gvolume.material = "G4_Al"
+	gvolume.publish(configuration)
 
-		# Heat Shield Half Sphere
-		z_center = 49.55
-		r_in = 40.3  # radius in mm
-		r_out = 41.3  # radius in mm
-		gvolume = GVolume("HeatShieldSphere")
-		gvolume.mother = "PolTarg"
-		gvolume.description = "PolTarg Heat Shield Exit window Shere"
-		gvolume.setPosition(0,0,z_center)
-		gvolume.color = "aaaaaa"
-		gvolume.makeG4Sphere(r_in, r_out, 0, 360, 0, 90)
-		gvolume.material = "G4_Al"
-		gvolume.publish(configuration)
+def build_geometry_bonus(configuration):
+	# bonus root volume
+	r_in = 0.0 # radius in mm
+	r_out = 4  # radius in mm
+	half_length = 225.0  # half length along beam axis
+	gvolume = GVolume("bonusTarget")
+	gvolume.mother = "root"
+	gvolume.description = "BONuS12 RTPC gaseous D2 Target"
+	gvolume.color =  "eeeegg"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_He"
+	gvolume.visible = "0"
+	gvolume.publish(configuration)
+	
+	# bonus target gas volume
+	r_in = 0.0
+	r_out = 3.0
+	half_length = 223.0  # half length
+	gvolume = GVolume("gasDeuteriumTarget")
+	gvolume.mother = "bonusTarget"
+	gvolume.description = "7 atm deuterium target gas"
+	gvolume.color =  "a54382"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "bonusTargetGas"
+	gvolume.publish(configuration)
+	
+	# bonus target wall
+	r_in = 3.01
+	r_out = 3.056
+	half_length = 223.0  # half length
+	gvolume = GVolume("bonusTargetWall")
+	gvolume.mother = "bonusTarget"
+	gvolume.description = "Bonus Target wall"
+	gvolume.color =  "330099"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_KAPTON"
+	gvolume.publish(configuration)
+	
+	# bonus target downstream aluminum end cap ring
+	r_in = 3.0561
+	r_out = 3.1561
+	half_length = 2.0  # half length
+	z_center = 221  # z position
+	gvolume = GVolume("bonusTargetEndCapRing")
+	gvolume.mother = "bonusTarget"
+	gvolume.description = "Bonus Target Al end cap ring"
+	gvolume.color =  "000000"
+	gvolume.setPosition(0,0,z_center)
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_Al"
+	gvolume.publish(configuration)
+	
+	# bonus target downstream aluminum end cap ring
+	r_in = 0.0
+	r_out = 3.1561
+	half_length = 0.05  # half length
+	z_center = 223.06  # z position
+	gvolume = GVolume("bonusTargetEndCapPlate")
+	gvolume.mother = "bonusTarget"
+	gvolume.description = "Bonus Target Al end cap wall"
+	gvolume.color =  "000000"
+	gvolume.setPosition(0,0,z_center)
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_Al"
+	gvolume.publish(configuration)
 
+def build_geometry_pb_test(configuration):
+	# mother is a helium bag 293.26 mm long. Its center is 40.85 mm
+	z_shift = 40.85
+	r_in = 0.0
+	r_out = 10.0
+	cell_half_length = 293.26 / 2
+	z_center = cell_half_length - z_shift
+	gvolume = GVolume("targetCell")
+	gvolume.mother = "root"
+	gvolume.description ="Helium cell"
+	gvolume.color =  "5511111"
+	gvolume.setPosition(0,0,z_center)
+	_make_full_tube(gvolume, r_in, r_out, cell_half_length)
+	gvolume.material = "G4_He"
+	gvolume.publish(configuration)
 
-VARIATIONBUILDER_MAP = {
+	# PB 125 microns
+	r_in = 0.0
+	r_out = 5.0
+	z_center = z_shift - cell_half_length
+	half_length = 0.0625 # (0.125 mm thick)
+	gvolume = GVolume("testPbTarget")
+	gvolume.mother = "targetCell"
+	gvolume.description ="Pb target"
+	gvolume.color =  "004488"
+	gvolume.setPosition(0,0,z_center)
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_Pb"
+	gvolume.publish(configuration)
+
+	# Upstream Foil 50 microns Aluminum at 24.8 cm
+	z_center = 0.1 - cell_half_length   # upstream end
+	r_in = 0.0
+	r_out = 5.0 
+	half_length = 0.015 # (0.030 mm thick)
+	gvolume = GVolume("AlTargetFoilUpstream")
+	gvolume.mother = "targetCell"
+	gvolume.description ="Aluminum Upstream Foil"
+	gvolume.color =  "aaaaaa"
+	gvolume.color =  "004488"
+	gvolume.setPosition(0,0,z_center)
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_Al"
+	gvolume.publish(configuration)
+
+	# Downstream Foil 50 microns Aluminum at 24.8 cm
+	z_center = cell_half_length - 0.1   # Downstream end
+	r_in = 0.0
+	r_out = 5.0
+	half_length = 0.015 # (0.030 mm thick)
+	gvolume = GVolume("AlTargetFoilDownstream")
+	gvolume.mother = "targetCell"
+	gvolume.description ="Aluminum Downstream Foil"
+	gvolume.color =  "aaaaaa"
+	gvolume.material = "G4_Al"
+	gvolume.setPosition(0,0,z_center)
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.publish(configuration)
+
+	# flux detector downstream of the scattering chamber
+	z_center = 300.0   
+	r_out = 45.0
+	half_length = 0.015 # (0.030 mm thick)
+	gvolume = GVolume("testFlux")
+	gvolume.mother = "root"
+	gvolume.description = "Flux detector"
+	gvolume.color = "009900"
+	gvolume.setPosition(0,0,z_center)
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material = "G4_AIR"
+	# gvolume.sensivity = "flux"
+	# gvolume.hit_type = "flux"
+	# gvolume.identifiers = "id manual 1"
+	gvolume.publish(configuration)
+
+def build_geometry_nd3(configuration):
+
+	variation = configuration.variation
+
+	# vacuum container
+	r_in = 0.0
+	r_out= 44.0
+	half_lenght = 50.0  # half length
+	gvolume = GVolume("scatteringChamberVacuum")
+	gvolume.description = f'clas12 scattering chamber vacuum rohacell container for {variation} target'
+	gvolume.color = "aaaaaa4"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material  = "G4_Galactic"
+	gvolume.publish(configuration)
+	
+	# rohacell
+	r_in = 0.0
+	r_out = 43.0
+	half_length = 48.0  # half length
+	gvolume = GVolume("scatteringChamber")
+	gvolume.mother = "scatteringChamberVacuum"
+	gvolume.description = f'clas12 rohacell scattering chamber for {variation} target'
+	gvolume.color = "ee3344"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material  = "rohacell"
+	gvolume.publish(configuration)
+	
+	# vacuum container for plastic cell
+	r_in = 0.0
+	r_out = 40.0
+	half_length = 45.0  # half length
+	gvolume = GVolume("plasticCellVacuum")
+	gvolume.mother = "scatteringChamber"
+	gvolume.description = f'clas12 rohacell vacuum aluminum container chamber for {variation} target'
+	gvolume.color = "aaaaaa4"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material  = "G4_Galactic"
+	gvolume.publish(configuration)
+	
+	# helium cylinder
+	r_in = 0.0
+	r_out = 12.62
+	half_length = 25.10  # half length
+	gvolume = GVolume("HeliumCell")
+	gvolume.mother = "plasticCellVacuum"
+	gvolume.description = f'Helium volume for {variation} target'
+	gvolume.color = "aaaaaa3"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	#gvolume.material  = "G4_He"
+	gvolume.material  = "G4_Galactic" #temporaly replacing with vacuum. Maria: What should we do here?
+	gvolume.publish(configuration)
+	
+	# plastic cylinder cell
+	r_in = 0.0
+	r_out = 12.60
+	half_length = 20.10  # half length
+	gvolume = GVolume("plasticCell")
+	gvolume.mother = "HeliumCell"
+	gvolume.description = f'clas12 plastic cell for {variation} target'
+	gvolume.color = "aaaaaa"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material  = "G4_TEFLON" #using teflon which is similar to the actual cell
+	gvolume.publish(configuration)
+	
+	# actual target
+	r_in = 0.0
+	r_out = 12.50 # target has a 25mm diameter
+	half_length = 20.00  # half length (target is 4cm long)
+	gvolume = GVolume(f'{variation}')
+	gvolume.mother = "plasticCell"
+	gvolume.description = f'clas12 {variation} target'
+	gvolume.color = "ee8811Q"
+	_make_full_tube(gvolume, r_in, r_out, half_length)
+	gvolume.material  = "solidND3"
+	gvolume.publish(configuration)
+
+VARIATION_MAP = {
 	"lh2": build_geometry_lhydrogen,
 	"lh2e": build_geometry_lhydrogen,
 	"ld2": build_geometry_lhydrogen,
 	"c12": build_geometry_c12,
-	"pol_targ": build_geometry_pol_targ
+	"pol_targ": build_geometry_pol_targ,
+	"bonus": build_geometry_bonus,
+	"pb_test": build_geometry_pb_test
 }

--- a/projects/clas12/targets/geometry.py
+++ b/projects/clas12/targets/geometry.py
@@ -507,7 +507,7 @@ def build_geometry_pol_targ(configuration):
 		gvolume.publish(configuration)
 
 
-MAP_TARGET_TO_BUILDER = {
+VARIATIONBUILDER_MAP = {
 	"lh2": build_geometry_lhydrogen,
 	"lh2e": build_geometry_lhydrogen,
 	"ld2": build_geometry_lhydrogen,

--- a/projects/clas12/targets/geometry.py
+++ b/projects/clas12/targets/geometry.py
@@ -565,7 +565,7 @@ def build_geometry_bonus(configuration):
 
 	for builder in [
 		build_bonus_root_volume,
-		build_bonus_target_gas_volume,
+		# build_bonus_target_gas_volume,
 		build_bonus_target_wall,
 		build_bonus_target_downstream_aluminum_end_cap_r_ing,
 		build_bonus_target_downstream_end_cap_r_ing,

--- a/projects/clas12/targets/geometry.py
+++ b/projects/clas12/targets/geometry.py
@@ -652,10 +652,9 @@ def build_geometry_pb_test(configuration):
 		gvolume.setPosition(0,0,z_center)
 		_make_full_tube(gvolume, r_in, r_out, half_length)
 		gvolume.material = "G4_AIR"
-		# @mariakzurek: sensitivity, hit_type, identifiers are not part of the current gemc3 API
-		# gvolume.sensivity = "flux"
-		# gvolume.hit_type = "flux"
-		# gvolume.identifiers = "id manual 1"
+		gvolume.sensivity = "flux"
+		gvolume.hit_type = "flux"
+		gvolume.identifiers = "id manual 1"
 		return gvolume
 
 	for builder in [
@@ -717,8 +716,7 @@ def build_geometry_nd3(configuration):
 		gvolume.description = f'Helium volume for {variation} target'
 		gvolume.color = "aaaaaa3"
 		_make_full_tube(gvolume, r_in, r_out, half_length)
-		#gvolume.material  = "G4_He"
-		gvolume.material  = "G4_Galactic" #temporaly replacing with vacuum. @mariakzurek: What should we do here?
+		gvolume.material  = "G4_He"
 		return gvolume
 
 	def build_plastic_cylinder_cell():
@@ -1055,7 +1053,6 @@ def build_geometry_pb208(configuration):
 
 
 def build_geometry_hdice(configuration):
-	# @mariakzurek: Is this the final implementation? What is the mfield field?
 	def build_target_container():	
 		gvolume = GVolume("hdIce_mother")
 		gvolume.mother = "root"
@@ -1131,7 +1128,6 @@ def build_geometry_longitudinal(configuration):
 		volume.publish(configuration)
 
 def build_geometry_transverse(configuration):
-	# @mariakzurek: all the volumes in this implementation have mother = root. Is it how we want to keep it?
 
 	#	half_length: 28.4 mm
 	#	ID: 27.0 mm
@@ -1149,7 +1145,7 @@ def build_geometry_transverse(configuration):
 		gvolume.description = "Target Container"
 		gvolume.color =  "222222"
 		_make_full_tube(gvolume, r_in, r_out, half_half_length)
-		gvolume.material = "Kel-F"
+		gvolume.material = "AmmoniaCellWalls"
 		return gvolume
 		
 	def build_target_cell():
@@ -1481,7 +1477,6 @@ def build_geometry_apollo(configuration):
 			heat_shield_r_in,
 			heat_shield_r_out,
 			heat_shield_window,
-			# @mariakzurek: should this be "HeatShield"?
 			"HeathShield",
 			"G4_Al",
 			"404040",

--- a/projects/clas12/targets/geometry.py
+++ b/projects/clas12/targets/geometry.py
@@ -740,7 +740,7 @@ def build_geometry_nd3(configuration):
 		gvolume = GVolume(f'{variation}')
 		gvolume.mother = "plasticCell"
 		gvolume.description = f'clas12 {variation} target'
-		gvolume.color = "ee8811Q"
+		gvolume.color = "ee8811"
 		_make_full_tube(gvolume, r_in, r_out, half_length)
 		gvolume.material  = "solidND3"
 		return gvolume

--- a/projects/clas12/targets/geometry.py
+++ b/projects/clas12/targets/geometry.py
@@ -1252,8 +1252,8 @@ def build_geometry_apollo(configuration):
 		phi_start = 0
 		phi_total = 360 
 		z_plane = [-volume_length, z_length]
-		outer_radius = [r_out]*n_planes
-		inner_radius = [0.0]*n_planes
+		outer_radius = [r_out, r_out]
+		inner_radius = [0.0, 0.0]
 		gvolume = GVolume("PolTarg")
 		gvolume.description = "PolTarg Region"
 		gvolume.color = "123456"
@@ -1269,8 +1269,8 @@ def build_geometry_apollo(configuration):
 		phi_start = 0
 		phi_total = 360 
 		z_plane = [-volume_length, spheres_center]
-		outer_radius = [r_out]*n_planes
-		inner_radius = [0.0]*n_planes
+		outer_radius = [r_out, r_out]
+		inner_radius = [0.0, 0.0]
 		gvolume = GVolume("VacuumVolume")
 		gvolume.mother = "PolTarg"
 		gvolume.description = "Vacuum cylindrical volume"
@@ -1398,12 +1398,12 @@ def build_geometry_apollo(configuration):
 
 	def build_beam_pipe():
 		# Beam pipe
-		r_in  = 0
+		r_in  = 0.0
 		r_out = target_radius+1
 		z1 = -bath_dz
 		z2 = -bath_z0-target_length/2-target_window_thickness
 		half_length = (z2-z1)/2
-		z_center     = (z2+z1)/2
+		z_center    = (z2+z1)/2
 		gvolume = GVolume("BeamEntranceVacuum")
 		gvolume.mother = "HeliumBath"
 		gvolume.description = "Beam Entrance Vacuum"
@@ -1508,11 +1508,12 @@ def build_geometry_apollo(configuration):
 		tube = GVolume(f"{name}Tube")
 		tube.mother = "VacuumVolume"
 		tube.description = f"{name} tube"
+		tube.setPosition(0,0,target_center)
 		tube.makeG4Polycone(
-			0.,
-			360.,
+			0,
+			360,
 			2,
-			[volume_length, spheres_center],
+			[-volume_length, spheres_center],
 			[r_in, r_in],
 			[r_out, r_out],
 		)
@@ -1522,12 +1523,12 @@ def build_geometry_apollo(configuration):
 		sphere = GVolume(f"{name}Sphere")
 		sphere.mother = "VacuumSphere"
 		sphere.description = f"{name} sphere"
-
+		sphere.setPosition(0,0,0)
 		sphere.makeG4Sphere(
 			r_in,
 			r_out,
-			0.,
-			360.,
+			0,
+			360,
 			theta,
 			dtheta,
 		)
@@ -1535,12 +1536,13 @@ def build_geometry_apollo(configuration):
 		window = GVolume(f"{name}Window")
 		window.description = f"{name} window"
 		window.mother = "VacuumSphere"
+		window.setPosition(0,0,0)
 		window.makeG4Sphere(
 			r_in,
 			r_out_window,
-			0.,
-			360.,
-			0.,
+			0,
+			360,
+			0,
 			theta
 		)
 

--- a/projects/clas12/targets/geometry.py
+++ b/projects/clas12/targets/geometry.py
@@ -652,9 +652,8 @@ def build_geometry_pb_test(configuration):
 		gvolume.setPosition(0,0,z_center)
 		_make_full_tube(gvolume, r_in, r_out, half_length)
 		gvolume.material = "G4_AIR"
-		gvolume.sensivity = "flux"
-		gvolume.hit_type = "flux"
-		gvolume.identifiers = "id manual 1"
+		gvolume.digitization = 'flux'
+		gvolume.setIdentifier('pbTargetTest',1)
 		return gvolume
 
 	for builder in [

--- a/projects/clas12/targets/geometry.py
+++ b/projects/clas12/targets/geometry.py
@@ -1,5 +1,36 @@
 from gemc_api_geometry import *
 
+import math
+
+
+def _make_full_tube(gvolume, r_in, r_out, half_length):
+	gvolume.makeG4Tubs(r_in, r_out, half_length, 0.0, 360.0)
+
+
+def _build_nuclear_target_foil(
+			material,
+			name_prefix,
+			descr_prefix,
+			z_center,
+			half_length,
+			r_in=0.0,
+			r_out=5.0,
+			color="aa0000",
+		):
+			r_out = 5.0
+			half_length = 0.86
+			r_in = 0.0
+
+			gvolume = GVolume(f"{name_prefix}NuclearTargFoil")
+			gvolume.mother = "target"
+			gvolume.description = f"{descr_prefix} foil for EG2p Nuclear Targets Assembly"
+			gvolume.material = material
+			gvolume.color = color
+			_make_full_tube(gvolume, r_in, r_out, half_length)
+			gvolume.setPosition(0., 0., z_center)
+			return gvolume
+
+
 def build_geometry_lhydrogen(configuration):
 
 	variation = configuration.variation
@@ -7,7 +38,7 @@ def build_geometry_lhydrogen(configuration):
 		"lh2": "G4_lH2",
 		"ld2": "LD2",
 		"lh2e": "G4_lH2"
-		}
+	}
 
 	z_plane_varmap = {
 		"lh2": [-140.0, 265.0, 280.0, 280.0],
@@ -29,6 +60,7 @@ def build_geometry_lhydrogen(configuration):
 		gvolume.makeG4Polycone(phi_start, phi_total, n_planes, z_plane, inner_radius, outer_radius)
 		gvolume.material = 'G4_Galactic'	# from GEANT4 materials database
 		gvolume.color = '22ff22'
+		gvolume.style = 0
 		return gvolume
 	
 	def build_target_cell():
@@ -39,9 +71,9 @@ def build_geometry_lhydrogen(configuration):
 		outer_radius = [2.5,  10.3,  7.3,  5.0,  2.5]
 		inner_radius = [0.0]*len(outer_radius)
 
-		gvolume = GVolume(variation)
+		gvolume = GVolume("lh2")
 		gvolume.mother = "target"
-		gvolume.description = f'Liquid Hydrogen Target Cell for vaiation {variation}'
+		gvolume.description = f'Liquid Hydrogen Target Cell for variation {variation}'
 		gvolume.makeG4Polycone(phi_start, phi_total, n_planes, z_plane, inner_radius, outer_radius)
 		gvolume.material = material_varmap[variation]
 		gvolume.color = 'aa0000'
@@ -53,6 +85,677 @@ def build_geometry_lhydrogen(configuration):
 	]: 
 		volume = builder()
 		volume.publish(configuration)
+
+
+def build_geometry_pol_targ(configuration):
+	
+	def build_vacuum_container():
+		r_in = 0
+		r_out = 44
+		half_length = 130
+		gvolume = GVolume("PolTarg")
+		gvolume.description = "PolTarg Region"
+		gvolume.color = "aaaaaa9"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Galactic"
+		return gvolume
+	
+	def build_lhe_between_target_cells():
+		z_center = 0  # center location of target along beam axis
+		r_in = 0
+		r_out = 10  # radius in mm
+		half_length = 14.97  # half length along beam axis
+		gvolume = GVolume("LHeVoidFill")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "LHe between target cells"
+		gvolume.color = "0000ff"
+		gvolume.setPosition(0,0,z_center)
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "lHeCoolant"
+		return gvolume
+	
+	def build_upstream_nh3_target_cell():
+		z_center = -25  # center location of target along beam axis
+		r_in = 0
+		r_out = 10  # radius in mm
+		half_length = 9.96  # half length along beam axis
+		gvolume = GVolume("NH3Targ")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Upstream NH3 target cell"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "f000f0"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "NH3target"
+		return gvolume
+
+	def build_upstream_nh3_target_cup():
+		z_center = -25
+		r_in = 10.0001  # radius in mm
+		r_out = 10.03  # radius in mm
+		half_length = 9.75  # half length along beam axis
+		gvolume = GVolume("NH3Cup")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Upstream NH3 Target cup"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "ffffff"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "AmmoniaCellWalls"
+		return gvolume
+
+	def build_upstream_nh3_target_cup_downstream_r_ing():
+		z_center = -35
+		r_in = 10.0001  # radius in mm
+		r_out = 11.43  # radius in mm
+		half_length = 0.25  # half length along beam axis
+		gvolume = GVolume("NH3CupDSr_ing")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Upstream NH3 Target cup downstream r_ing"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "ffffff"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "AmmoniaCellWalls"
+		return gvolume
+
+	def build_upstream_nh3_target_cup_upstream_r_ing():
+		z_center = -15
+		r_in = 10.0001  # radius in mm
+		r_out = 12.7  # radius in mm
+		half_length = 0.25  # half length along beam axis
+		gvolume = GVolume("NH3CupUSr_ing")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Upstream NH3 Target cup Upstream r_ing"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "ffffff"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "AmmoniaCellWalls"
+		return gvolume
+
+	def build_upstream_nh3_target_cup_window_frame():
+		z_center = -35
+		r_in = 11.44  # radius in mm
+		r_out = 12.7  # radius in mm
+		half_length = 1.5875  # half length along beam axis
+		gvolume = GVolume("NH3CupWindowFrame_20")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Upstream NH3 Target cup Window frame"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "ffffff"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "AmmoniaCellWalls"
+		return gvolume
+
+	def build_upstream_nh3_target_cup_upstream_window():
+		z_center = -35
+		r_in = 0  # radius in mm
+		r_out = 10  # radius in mm
+		half_length = 0.025  # half length along beam axis	
+		gvolume = GVolume("NH3CupUSWindow_20")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Upstream NH3 Target cup Upstream Window"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "aaaaaa"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	def build_upstream_nh3_target_cup_downstream_window():
+		z_center = -15
+		r_in = 0  # radius in mm
+		r_out = 10  # radius in mm
+		half_length = 0.025  # half length along beam axis
+		gvolume = GVolume("NH3CupDSWindow")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Upstream NH3 Target cup Downstream Window"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "aaaaaa"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	def build_downstream_nd3_target_cell():
+		z_center = 25  # center location of target along beam axis
+		r_in = 0
+		r_out = 10  # radius in mm
+		half_length = 9.96  # half length along beam axis	
+		gvolume = GVolume("ND3Targ")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Downstream ND3 target cell"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "f000f0"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "ND3target"
+		return gvolume
+
+	def build_downstream_nd3_target_cup():
+		z_center = 25
+		r_in = 10.0001  # radius in mm
+		r_out = 10.03  # radius in mm
+		half_length = 9.75  # half length along beam axis
+		gvolume = GVolume("ND3Cup")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Downstream ND3 Target cup"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "ffffff"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "AmmoniaCellWalls"
+		return gvolume
+
+	def build_downstream_nd3_target_cup_downstream_r_ing():
+		z_center = 35
+		r_in = 10.0001  # radius in mm
+		r_out = 11.43  # radius in mm
+		half_length = 0.25  # half length along beam axis
+		gvolume = GVolume("ND3CupDSr_ing")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Downstream ND3 Target cup downstream r_ing"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "ffffff"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "AmmoniaCellWalls"
+		return gvolume
+
+	def build_downstream_nd3_target_cup_upstream_r_ing():
+		z_center = 15
+		r_in = 10.0001  # radius in mm
+		r_out = 11.43  # radius in mm
+		half_length = 0.25  # half length along beam axis
+		gvolume = GVolume("ND3CupUSr_ing")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Downstrem ND3 Target cup Upstream r_ing"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "ffffff"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "AmmoniaCellWalls"
+		return gvolume
+
+	def build_downstream_nd3_target_cup_window_frame():
+		z_center = 15
+		r_in = 11.44  # radius in mm
+		r_out = 12.7  # radius in mm
+		half_length = 1.5875  # half length along beam axis
+		gvolume = GVolume("ND3CupWindowFrame_20")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Downstream ND3 Target cup Window frame"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "ffffff"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "AmmoniaCellWalls"
+		return gvolume
+
+	def build_downstream_nd3_target_cup_upstream_window():
+		z_center = 35
+		r_in = 0.0  # radius in mm
+		r_out = 10.0  # radius in mm
+		half_length = 0.025  # half length along beam axis	
+		gvolume = GVolume("ND3CupUSWindow_20")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Downstream ND3 Target cup Upstream Window"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "aaaaaa"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	def build_downstream_nd3_target_cup_downstream_window():
+		z_center = 15
+		r_in = 0.0  # radius in mm
+		r_out = 10.0  # radius in mm
+		half_length = 0.025  # half length along beam axis	
+		gvolume = GVolume("ND3CupDSWindow")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Downstream ND3 Target cup Downstream Window"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "aaaaaa"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	def build_bath_entrance_window_part_7a():
+		z_center = -37.395
+		r_in = 0.0  # radius in mm
+		r_out = 11.5  # radius in mm
+		half_length = 0.605  # half length along beam axis
+		gvolume = GVolume("InsertBathEntranceWindow_7a")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Insert Bath Entrance window part 7 a"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "aaaaaa"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	def build_bath_entrance_window_part_7b():
+		z_center = -68.2
+		r_in = 11.0  # radius in mm
+		r_out = 11.5  # radius in mm
+		half_length = 30.1  # half length along beam axis
+		gvolume = GVolume("InsertBathEntranceWindow_7b")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Insert Bath Entrence window part 7 b"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "aaaaaa"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	def build_bath_entrance_window_part_7c():
+		z_center = -98.4
+		r_in = 11.5001  # radius in mm
+		r_out = 14.4  # radius in mm
+		half_length = 3.17  # half length along beam axis
+		gvolume = GVolume("InsertBathEntranceWindow_7c")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Insert Bath Entrence window part 7 c"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "aaaaaa"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	def build_bath_entrance_window_part_7c():
+		z_center = -102.23
+		r_in = 11.0  # radius in mm
+		r_out = 14.96  # radius in mm
+		half_length = 0.66  # half length along beam axis
+		gvolume = GVolume("InsertBathEntranceWindow_7d")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Insert Bath Entrence window part 7 d"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "aaaaaa"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+	
+	def build_shim_coil_carrier():
+		z_center = -19.3
+		r_in = 28.8  # radius in mm
+		r_out = 29.3  # radius in mm
+		half_length = 80.95  # half length along beam axis	
+		gvolume = GVolume("ShimCoilCarrier")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Shim coil Carrier"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "aaaaaa"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	def build_shim_up_upstream_coil():
+		z_center = 43.5
+		r_in = 29.3  # radius in mm
+		r_out = 30.0  # radius in mm
+		half_length = 6.0  # half length along beam axis
+		gvolume = GVolume("ShimUpUpS")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Shim Up Upstream Coil"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "a00000"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "ShimCoil"
+		return gvolume
+
+	def build_shim_upstream_coil():
+		z_center = 8.5
+		r_in = 29.3  # radius in mm
+		r_out = 30.0  # radius in mm
+		half_length = 6.0  # half length along beam axis
+		gvolume = GVolume("ShimUpS")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Shim coil upstream"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "a00000"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "ShimCoil"
+		return gvolume
+
+	def build_shim_downstream_coil():
+		z_center = -8.5
+		r_in = 29.3  # radius in mm
+		r_out = 30.0  # radius in mm
+		half_length = 6.0  # half length along beam axis
+		gvolume = GVolume("ShimDownS")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Shim coil downstream"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "a00000"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "ShimCoil"
+		return gvolume
+
+	def build_shim_down_downstream_coil():
+		z_center = -43.5
+		r_in = 29.3  # radius in mm
+		r_out = 30.0  # radius in mm
+		half_length = 6.0  # half length along beam axis
+		gvolume = GVolume("ShimDownDownS")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Shim coil Down downstream"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "a00000"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "ShimCoil"
+		return gvolume
+	
+	def build_heat_shield_tube():
+		z_center = -34.3
+		r_in = 40.3  # radius in mm
+		r_out = 41.3  # radius in mm
+		half_length = 83.85  # half length along beam axis
+		gvolume = GVolume("HeatShieldTube")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "PolTarg Heat Shield Tube"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "aaaaaa"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	def build_heat_shield_halfsphere():
+		z_center = 49.55
+		r_in = 40.3  # radius in mm
+		r_out = 41.3  # radius in mm
+		gvolume = GVolume("HeatShieldSphere")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "PolTarg Heat Shield Exit window Shere"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "aaaaaa"
+		gvolume.makeG4Sphere(r_in, r_out, 0, 360, 0, 90)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	for builder in [
+		build_vacuum_container,
+		build_lhe_between_target_cells,
+		build_upstream_nh3_target_cell,
+		build_upstream_nh3_target_cup,
+		build_upstream_nh3_target_cup_downstream_r_ing,
+		build_upstream_nh3_target_cup_upstream_r_ing,
+		build_upstream_nh3_target_cup_window_frame,
+		build_upstream_nh3_target_cup_upstream_window,
+		build_upstream_nh3_target_cup_downstream_window,
+		build_downstream_nd3_target_cell,
+		build_downstream_nd3_target_cup,
+		build_downstream_nd3_target_cup_downstream_r_ing,
+		build_downstream_nd3_target_cup_upstream_r_ing,
+		build_downstream_nd3_target_cup_window_frame,
+		build_downstream_nd3_target_cup_upstream_window,
+		build_downstream_nd3_target_cup_downstream_window,
+		build_bath_entrance_window_part_7a,
+		build_bath_entrance_window_part_7b,
+		build_bath_entrance_window_part_7c,
+		build_bath_entrance_window_part_7c,
+		build_shim_coil_carrier,
+		build_shim_up_upstream_coil,
+		build_shim_upstream_coil,
+		build_shim_downstream_coil,
+		build_shim_down_downstream_coil,
+		build_heat_shield_tube,
+		build_heat_shield_halfsphere,
+	]:
+		volume = builder()
+		volume.publish(configuration)
+
+
+def build_geometry_bonus(configuration):
+
+	def build_bonus_root_volume():
+		r_in = 0.0 # radius in mm
+		r_out = 4  # radius in mm
+		half_length = 225.0  # half length along beam axis
+		gvolume = GVolume("bonusTarget")
+		gvolume.mother = "root"
+		gvolume.description = "BONuS12 RTPC gaseous D2 Target"
+		gvolume.color =  "eeeegg"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_He"
+		gvolume.visible = 0
+		return gvolume
+	
+	def build_bonus_target_gas_volume():
+		r_in = 0.0
+		r_out = 3.0
+		half_length = 223.0  # half length
+		gvolume = GVolume("gasDeuteriumTarget")
+		gvolume.mother = "bonusTarget"
+		gvolume.description = "7 atm deuterium target gas"
+		gvolume.color =  "a54382"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "bonusTargetGas"
+		return gvolume
+	
+	def build_bonus_target_wall():
+		r_in = 3.01
+		r_out = 3.056
+		half_length = 223.0  # half length
+		gvolume = GVolume("bonusTargetWall")
+		gvolume.mother = "bonusTarget"
+		gvolume.description = "Bonus Target wall"
+		gvolume.color =  "330099"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_KAPTON"
+		return gvolume
+
+	def build_bonus_target_downstream_aluminum_end_cap_r_ing():
+		r_in = 3.0561
+		r_out = 3.1561
+		half_length = 2.0  # half length
+		z_center = 221  # z position
+		gvolume = GVolume("bonusTargetEndCapr_ing")
+		gvolume.mother = "bonusTarget"
+		gvolume.description = "Bonus Target Al end cap r_ing"
+		gvolume.color =  "000000"
+		gvolume.setPosition(0,0,z_center)
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	def build_bonus_target_downstream_end_cap_r_ing():
+		r_in = 0.0
+		r_out = 3.1561
+		half_length = 0.05  # half length
+		z_center = 223.06  # z position
+		gvolume = GVolume("bonusTargetEndCapPlate")
+		gvolume.mother = "bonusTarget"
+		gvolume.description = "Bonus Target Al end cap wall"
+		gvolume.color =  "000000"
+		gvolume.setPosition(0,0,z_center)
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	for builder in [
+		build_bonus_root_volume,
+		build_bonus_target_gas_volume,
+		build_bonus_target_wall,
+		build_bonus_target_downstream_aluminum_end_cap_r_ing,
+		build_bonus_target_downstream_end_cap_r_ing,
+	]:
+		volume = builder()
+		volume.publish(configuration)
+
+
+def build_geometry_pb_test(configuration):
+
+	z_shift = 40.85
+	cell_half_length = 293.26 / 2
+
+	def build_helium_bag():
+		# mother is a helium bag 293.26 mm long. Its center is 40.85 mm
+		r_in = 0.0
+		r_out = 10.0
+		z_center = cell_half_length - z_shift
+		gvolume = GVolume("targetCell")
+		gvolume.mother = "root"
+		gvolume.description ="Helium cell"
+		gvolume.color =  "5511111"
+		gvolume.setPosition(0,0,z_center)
+		_make_full_tube(gvolume, r_in, r_out, cell_half_length)
+		gvolume.material = "G4_He"
+		return gvolume
+
+	def build_pb_125_microns():
+		# PB 125 microns
+		r_in = 0.0
+		r_out = 5.0
+		z_center = z_shift - cell_half_length
+		half_length = 0.0625 # (0.125 mm thick)
+		gvolume = GVolume("testPbTarget")
+		gvolume.mother = "targetCell"
+		gvolume.description ="Pb target"
+		gvolume.color =  "004488"
+		gvolume.setPosition(0,0,z_center)
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Pb"
+		return gvolume
+
+	def build_upstream_foil_al():
+		# Upstream Foil 50 microns Aluminum at 24.8 cm
+		z_center = 0.1 - cell_half_length   # upstream end
+		r_in = 0.0
+		r_out = 5.0 
+		half_length = 0.015 # (0.030 mm thick)
+		gvolume = GVolume("AlTargetFoilUpstream")
+		gvolume.mother = "targetCell"
+		gvolume.description ="Aluminum Upstream Foil"
+		gvolume.color =  "aaaaaa"
+		gvolume.color =  "004488"
+		gvolume.setPosition(0,0,z_center)
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	def build_downstream_foil_al():
+		# Downstream Foil 50 microns Aluminum at 24.8 cm
+		z_center = cell_half_length - 0.1   # Downstream end
+		r_in = 0.0
+		r_out = 5.0
+		half_length = 0.015 # (0.030 mm thick)
+		gvolume = GVolume("AlTargetFoilDownstream")
+		gvolume.mother = "targetCell"
+		gvolume.description ="Aluminum Downstream Foil"
+		gvolume.color =  "aaaaaa"
+		gvolume.material = "G4_Al"
+		gvolume.setPosition(0,0,z_center)
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		return gvolume
+
+	def build_flux_detector():
+		# flux detector downstream of the scatter_ing chamber
+		z_center = 300.0   
+		r_out = 45.0
+		r_in = 0.0
+		half_length = 0.015 # (0.030 mm thick)
+		gvolume = GVolume("testFlux")
+		gvolume.mother = "root"
+		gvolume.description = "Flux detector"
+		gvolume.color = "009900"
+		gvolume.setPosition(0,0,z_center)
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_AIR"
+		# @mariakzurek: sensitivity, hit_type, identifiers are not part of the current gemc3 API
+		# gvolume.sensivity = "flux"
+		# gvolume.hit_type = "flux"
+		# gvolume.identifiers = "id manual 1"
+		return gvolume
+
+	for builder in [
+		build_helium_bag,
+		build_pb_125_microns,
+		build_upstream_foil_al,
+		build_downstream_foil_al,
+		build_flux_detector,
+	]:
+		volume = builder()
+		volume.publish(configuration)
+
+
+def build_geometry_nd3(configuration):
+
+	variation = configuration.variation
+
+	def build_vacuum_container():
+		r_in = 0.0
+		r_out= 44.0
+		half_length = 50.0  # half length
+		gvolume = GVolume("scatter_ingChamberVacuum")
+		gvolume.description = f'clas12 scatter_ing chamber vacuum rohacell container for {variation} target'
+		gvolume.color = "aaaaaa4"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material  = "G4_Galactic"
+		return gvolume
+
+	def build_rohacell():
+		r_in = 0.0
+		r_out = 43.0
+		half_length = 48.0  # half lSength
+		gvolume = GVolume("scatter_ingChamber")
+		gvolume.mother = "scatter_ingChamberVacuum"
+		gvolume.description = f'clas12 rohacell scatter_ing chamber for {variation} target'
+		gvolume.color = "ee3344"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material  = "rohacell"
+		return gvolume
+
+	def build_vacuum_container_for_plastic_cell():
+		r_in = 0.0
+		r_out = 40.0
+		half_length = 45.0  # half length
+		gvolume = GVolume("plasticCellVacuum")
+		gvolume.mother = "scatter_ingChamber"
+		gvolume.description = f'clas12 rohacell vacuum aluminum container chamber for {variation} target'
+		gvolume.color = "aaaaaa4"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material  = "G4_Galactic"
+		return gvolume
+
+	def build_helium_cylinder():
+		r_in = 0.0
+		r_out = 12.62
+		half_length = 25.10  # half length
+		gvolume = GVolume("HeliumCell")
+		gvolume.mother = "plasticCellVacuum"
+		gvolume.description = f'Helium volume for {variation} target'
+		gvolume.color = "aaaaaa3"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		#gvolume.material  = "G4_He"
+		gvolume.material  = "G4_Galactic" #temporaly replacing with vacuum. @mariakzurek: What should we do here?
+		return gvolume
+
+	def build_plastic_cylinder_cell():
+		r_in = 0.0
+		r_out = 12.60
+		half_length = 20.10  # half length
+		gvolume = GVolume("plasticCell")
+		gvolume.mother = "HeliumCell"
+		gvolume.description = f'clas12 plastic cell for {variation} target'
+		gvolume.color = "aaaaaa"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material  = "G4_TEFLON" #using teflon which is similar to the actual cell
+		return gvolume
+
+	def build_actual_target():
+		r_in = 0.0
+		r_out = 12.50 # target has a 25mm diameter
+		half_length = 20.00  # half length (target is 4cm long)
+		gvolume = GVolume(f'{variation}')
+		gvolume.mother = "plasticCell"
+		gvolume.description = f'clas12 {variation} target'
+		gvolume.color = "ee8811Q"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material  = "solidND3"
+		return gvolume
+
+	for builder in [
+		build_vacuum_container,
+		build_rohacell,
+		build_vacuum_container_for_plastic_cell,
+		build_helium_cylinder,
+		build_plastic_cylinder_cell,
+		build_actual_target,
+	]:
+		volume = builder()
+		volume.publish(configuration)
+
 
 def build_geometry_c12(configuration):
 	def build_vacuum_container():
@@ -68,664 +771,857 @@ def build_geometry_c12(configuration):
 		gvolume.makeG4Polycone(phi_start, phi_total, n_planes, z_plane, inner_radius, outer_radius)
 		gvolume.material = 'G4_Galactic'	
 		gvolume.color = '22ff22'
+		gvolume.style = 0
 		return gvolume
 
-	def build_foil(
-			name_prefix,
-			descr_prefix,
-			z_center,
-			color="aa0000",
-		):
-			r_out = 5.0
-			half_length = 0.86
-			r_in = 0.0
-			phi_start = 0.0
-			phi_total = 360.0
-
-			gvolume = GVolume(f"{name_prefix}NuclearTargFoil")
-			gvolume.mother = "target"
-			gvolume.description = f"{descr_prefix} 12C foil for EG2p Nuclear Targets Assembly"
-			gvolume.material = "G4_C"
-			gvolume.color = color
-			gvolume.makeG4Tubs(r_in, r_out, half_length, phi_start, phi_total)
-			gvolume.setPosition(0., 0., z_center)
-			return gvolume
-
-
 	def build_upstream_foil():
-		return build_foil(
+		return _build_nuclear_target_foil(
+			material="G4_C",
 			name_prefix="1st",
-			descr_prefix="First",
+			descr_prefix="First C12",
 			z_center=-25.86,
+			half_length=0.86,
 			color="aa0011",
 		)
-	
+
 	def build_second_foil():
-		return build_foil(
+		return _build_nuclear_target_foil(
+			material="G4_C",
 			name_prefix="2nd",
-			descr_prefix="Second",
+			descr_prefix="Second C12",
 			z_center=24.14,
+			half_length=0.86,
+			color="aa0000",
 		)
 
-	def build_third_foil():
-		return build_foil(
+	def build_downstream_foil():
+		return _build_nuclear_target_foil(
+			material="G4_C",
 			name_prefix="3rd",
-			descr_prefix="Third",
+			descr_prefix="Third C12",
 			z_center=74.14,
+			half_length=0.86,
+			color="aa0000",
 		)
 
 	for builder in [
 		build_vacuum_container,
 		build_upstream_foil,
 		build_second_foil,
-		build_third_foil
+		build_downstream_foil
 	]:
 		volume = builder()
 		volume.publish(configuration)
 
 
-def _make_full_tube(gvolume, r_in, r_out, half_length):
-	gvolume.makeG4Tubs(r_in, r_out, half_length, 0.0, 360.0)
+def build_geometry_al27(configuration):
+
+	def build_vacuum_target():	
+		#Vacuum Target Container
+		n_planes = 4
+		phi_start = 0
+		phi_total = 360 
+
+		outer_radius = [50.2, 50.2, 21.0, 21.0]
+		z_plane = [-115.0, 265.0, 290.0, 373.0]
+		inner_radius = [0.0]*len(outer_radius)
+
+		gvolume = GVolume('target')
+		gvolume.description = 'Vacuum Container'
+		gvolume.makeG4Polycone(phi_start, phi_total, n_planes, z_plane, inner_radius, outer_radius)
+		gvolume.color =  "22ff22"
+		gvolume.material = "G4_Galactic"
+		gvolume.style = 0
+		return gvolume
+
+	def build_upstream_foil():
+		return _build_nuclear_target_foil(
+			material="G4_Al",
+			name_prefix="1st",
+			descr_prefix="First 27Al",
+			z_center=-25.29,
+			half_length=0.29,
+			color="aa0011",
+		)
+
+	def build_second_foil():
+		return _build_nuclear_target_foil(
+			material="G4_Al",
+			name_prefix="2nd",
+			descr_prefix="Second 27Al",
+			z_center=24.71,
+			half_length=0.29,
+			color="aa0000",
+		)
+
+	def build_downstream_foil():
+		return _build_nuclear_target_foil(
+			material="G4_Al",
+			name_prefix="3rd",
+			descr_prefix="Third 27Al",
+			z_center=74.71,
+			half_length=0.29,
+			color="aa0000",
+		)
+
+	for builder in [
+		build_vacuum_target,
+		build_upstream_foil,
+		build_second_foil,
+		build_downstream_foil
+	]:
+		volume = builder()
+		volume.publish(configuration)
 
 
-def build_geometry_pol_targ(configuration):
-	# vacuum container
-	r_in = 0
-	r_out = 44
-	half_length = 130
-	gvolume = GVolume("PolTarg")
-	gvolume.description = "PolTarg Region"
-	gvolume.color = "aaaaaa9"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_Galactic"
-	gvolume.publish(configuration)
+def build_geometry_cu63(configuration):
+
+	def build_vacuum_target():	
+		#Vacuum Target Container
+		n_planes = 4
+		phi_start = 0
+		phi_total = 360 
+
+		outer_radius = [50.2, 50.2, 21.0, 21.0]
+		z_plane = [-115.0,  265.0, 290.0, 373.0]
+		inner_radius = [0.0]*len(outer_radius)
+
+		gvolume = GVolume('target')
+		gvolume.description = 'Vacuum Container'
+		gvolume.makeG4Polycone(phi_start, phi_total, n_planes, z_plane, inner_radius, outer_radius)
+		gvolume.color =  "22ff22"
+		gvolume.material = "G4_Galactic"
+		gvolume.style = 0
+		return gvolume
+
+	def build_upstream_foil():
+		return _build_nuclear_target_foil(
+			material="G4_Cu",
+			name_prefix="1st",
+			descr_prefix="First 63Cu",
+			z_center=-25.2,
+			half_length=0.2,
+			color="aa0011",
+		)
+
+	def build_second_foil():
+		return _build_nuclear_target_foil(
+			material="G4_Cu",
+			name_prefix="2nd",
+			descr_prefix="Second 63Cu",
+			z_center=24.8,
+			half_length=0.2,
+			color="aa0000",
+		)
+
+	def build_downstream_foil():
+		return _build_nuclear_target_foil(
+			material="G4_Cu",
+			name_prefix="3rd",
+			descr_prefix="Third 63Cu",
+			z_center=74.8,
+			half_length=0.2,
+			color="aa0000",
+		)
+
+	for builder in [
+		build_vacuum_target,
+		build_upstream_foil,
+		build_second_foil,
+		build_downstream_foil
+	]:
+		volume = builder()
+		volume.publish(configuration)
+
+		
+def build_geometry_sn118(configuration):
+
+	def build_vacuum_target():	
+		#Vacuum Target Container
+		n_planes = 4
+		phi_start = 0
+		phi_total = 360 
+
+		outer_radius = [50.2, 50.2, 21.0, 21.0]
+		z_plane = [-115.0,  265.0, 290.0, 373.0]
+		inner_radius = [0.0]*len(outer_radius)
+
+		gvolume = GVolume('target')
+		gvolume.description = 'Vacuum Container'
+		gvolume.makeG4Polycone(phi_start, phi_total, n_planes, z_plane, inner_radius, outer_radius)
+		gvolume.color =  "22ff22"
+		gvolume.material = "G4_Galactic"
+		gvolume.style = 0
+		return gvolume
+
+	def build_upstream_foil():
+		return _build_nuclear_target_foil(
+			material="G4_Sn",
+			name_prefix="1st",
+			descr_prefix="First 118Sn",
+			z_center=-25.2,
+			half_length=0.15,
+			color="aa0011",
+		)
+
+	def build_second_foil():
+		return _build_nuclear_target_foil(
+			material="G4_Sn",
+			name_prefix="2nd",
+			descr_prefix="Second 118Sn",
+			z_center=24.85,
+			half_length=0.15,
+			color="aa0000",
+		)
+
+	def build_downstream_foil():
+		return _build_nuclear_target_foil(
+			material="G4_Sn",
+			name_prefix="3rd",
+			descr_prefix="Third 118Sn",
+			z_center=74.85,
+			half_length=0.15,
+			color="aa0000",
+		)
+
+	for builder in [
+		build_vacuum_target,
+		build_upstream_foil,
+		build_second_foil,
+		build_downstream_foil
+	]:
+		volume = builder()
+		volume.publish(configuration)
+		
+
+def build_geometry_pb208(configuration):
+
+	def build_vacuum_target():	
+		#Vacuum Target Container
+		n_planes = 4
+		phi_start = 0
+		phi_total = 360 
+
+		outer_radius = [50.2, 50.2, 21.0, 21.0]
+		z_plane = [-115.0,  265.0, 290.0, 373.0]
+		inner_radius = [0.0]*len(outer_radius)
+
+		gvolume = GVolume('target')
+		gvolume.description = 'Vacuum Container'
+		gvolume.makeG4Polycone(phi_start, phi_total, n_planes, z_plane, inner_radius, outer_radius)
+		gvolume.color =  "22ff22"
+		gvolume.material = "G4_Galactic"
+		gvolume.style = 0
+		return gvolume
+
+	def build_upstream_foil():
+		return _build_nuclear_target_foil(
+			material="G4_Pb",
+			name_prefix="1st",
+			descr_prefix="First 208Pb",
+			z_center=-25.07,
+			half_length=0.07,
+			color="aa0011",
+		)
+
+	def build_second_foil():
+		return _build_nuclear_target_foil(
+			material="G4_Pb",
+			name_prefix="2nd",
+			descr_prefix="Second 208Pb",
+			z_center=24.93,
+			half_length=0.07,
+			color="aa0000",
+		)
+
+	def build_downstream_foil():
+		return _build_nuclear_target_foil(
+			material="G4_Pb",
+			name_prefix="3rd",
+			descr_prefix="Third 208Pb",
+			z_center=74.93,
+			half_length=0.07,
+			color="aa0000",
+		)
+
+	for builder in [
+		build_vacuum_target,
+		build_upstream_foil,
+		build_second_foil,
+		build_downstream_foil
+	]:
+		volume = builder()
+		volume.publish(configuration)		
+
+
+def build_geometry_hdice(configuration):
+	# @mariakzurek: Is this the final implementation? What is the mfield field?
+	def build_target_container():	
+		gvolume = GVolume("hdIce_mother")
+		gvolume.mother = "root"
+		gvolume.description = "Target Container"
+		gvolume.color =  "22ff22"
+		gvolume.makeG4Box(160.0, 160.0, 800.0)
+		gvolume.material = "G4_Galactic"
+		gvolume.style = 0
+		gvolume.mfield = "hdicefield"
+		return gvolume
+
+	for builder in [
+		build_target_container
+	]:
+		volume = builder()
+		volume.publish(configuration)
+
+def build_geometry_longitudinal(configuration):
+
+	def build_vacuum_target():	
+		#Vacuum Target Container
+		n_planes = 4
+		phi_start = 0
+		phi_total = 360 
+
+		outer_radius = [50.2, 50.2, 21.0, 21.0]
+		z_plane = [-115.0,  265.0, 290.0, 300.0]
+		inner_radius = [0.0]*len(outer_radius)
+
+		gvolume = GVolume('ltarget') 
+		gvolume.description = 'Vacuum Container'
+		gvolume.makeG4Polycone(phi_start, phi_total, n_planes, z_plane, inner_radius, outer_radius)
+		gvolume.color =  "22ff22"
+		gvolume.material = "G4_Galactic"
+		gvolume.style = 0
+		return gvolume	
+
+	def build_aluminum_entrance_window():
+		z_center = -24.2125  # center location of target along beam axis
+		r_out = 5.0
+		r_in = 0.0
+		half_length = 0.0125
+		gvolume = GVolume("al_window_entrance")
+		gvolume.mother = "ltarget"
+		gvolume.description = "5 mm radius aluminum window upstream"
+		gvolume.color =  "aaaaff"
+		gvolume.setPosition(0,0,z_center)
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	def build_aluminum_exit_window():
+		z_center = 173.2825  # center location of target along beam axis
+		r_out = 3.175
+		r_in = 0.0
+		half_length = 0.0125
+		gvolume = GVolume("al_window_exit")
+		gvolume.mother = "ltarget"
+		gvolume.description = "1/8 in radius aluminum window downstream" 
+		gvolume.color =  "aaaaff"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.setPosition(0,0,z_center)
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
 	
-	# LHe fill between targets
-	z_center = 0  # center location of target along beam axis
-	r_in = 0
-	r_out = 10  # radius in mm
-	half_length = 14.97  # half length along beam axis
-	gvolume = GVolume("LHeVoidFill")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "LHe between target cells"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "0000ff"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "lHeCoolant"
-	gvolume.publish(configuration)
-	
-	# NH3Targ
-	z_center = -25  # center location of target along beam axis
-	r_in = 0
-	r_out = 10  # radius in mm
-	half_length = 9.96  # half length along beam axis
-	gvolume = GVolume("NH3Targ")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Upstream NH3 target cell"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "f000f0"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "NH3target"
-	gvolume.publish(configuration)
+	for builder in [
+		build_vacuum_target,
+		build_aluminum_entrance_window,
+		build_aluminum_exit_window
+	]:
+		volume = builder()
+		volume.publish(configuration)
 
-	# NH3Targ Cup
-	z_center = -25
-	r_in = 10.0001  # radius in mm
-	r_out = 10.03  # radius in mm
-	half_length = 9.75  # half length along beam axis
-	gvolume = GVolume("NH3Cup")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Upstream NH3 Target cup"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "ffffff"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "AmmoniaCellWalls"
-	gvolume.publish(configuration)
+def build_geometry_transverse(configuration):
+	# @mariakzurek: all the volumes in this implementation have mother = root. Is it how we want to keep it?
 
-	# NH3Targ Cup Down Stream Ring
-	z_center = -35
-	r_in = 10.0001  # radius in mm
-	r_out = 11.43  # radius in mm
-	half_length = 0.25  # half length along beam axis
-	gvolume = GVolume("NH3CupDSRing")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Upstream NH3 Target cup downstream Ring"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "ffffff"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "AmmoniaCellWalls"
-	gvolume.publish(configuration)
+	#	half_length: 28.4 mm
+	#	ID: 27.0 mm
+	#	OD: 29.0
+	#	Al foils: 25 um thick
 
-	# NH3Targ Cup UP Stream Ring
-	z_center = -15
-	r_in = 10.0001  # radius in mm
-	r_out = 12.7  # radius in mm
-	half_length = 0.25  # half length along beam axis
-	gvolume = GVolume("NH3CupUSRing")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Upstream NH3 Target cup Upstream Ring"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "ffffff"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "AmmoniaCellWalls"
-	gvolume.publish(configuration)
+	half_half_length = 14.2 # half half_length
+	foil_half_half_length = 0.0125 # half half_length
 
-	# NH3Targ Cup Window Frame
-	z_center = -35
-	r_in = 11.44  # radius in mm
-	r_out = 12.7  # radius in mm
-	half_length = 1.5875  # half length along beam axis
-	gvolume = GVolume("NH3CupWindowFrame_20")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Upstream NH3 Target cup Window frame"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "ffffff"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "AmmoniaCellWalls"
-	gvolume.publish(configuration)
+	def build_target_cell_frame():	
+		r_out = 14.5 
+		r_in = 0.0	
+		gvolume = GVolume("ttargetCellFrame")
+		gvolume.mother = "root"
+		gvolume.description = "Target Container"
+		gvolume.color =  "222222"
+		_make_full_tube(gvolume, r_in, r_out, half_half_length)
+		gvolume.material = "Kel-F"
+		return gvolume
+		
+	def build_target_cell():
+		# cell
+		r_out = 13.5
+		r_in = 0.0	
+		gvolume = GVolume("ttargetCell")
+		gvolume.mother = "root"
+		gvolume.description = "Target Container"
+		gvolume.color =  "994422"
+		_make_full_tube(gvolume, r_in, r_out, half_half_length)
+		gvolume.material = "NH3target"
+		return gvolume
 
-	# NH3Targ Cup Up Stream Window
-	z_center = -35
-	r_in = 0  # radius in mm
-	r_out = 10  # radius in mm
-	half_length = 0.025  # half length along beam axis	
-	gvolume = GVolume("NH3CupUSWindow_20")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Upstream NH3 Target cup Upstream Window"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "aaaaaa"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_Al"
-	gvolume.publish(configuration)
+	def build_aluminum_entrance_window():
+		# downstream al window
+		r_out = 13.5
+		r_in = 0.0
+		z_center = half_half_length + foil_half_half_length
+		gvolume = GVolume("al_window_entrance")
+		gvolume.mother = "root"
+		gvolume.description = "25 mm thick aluminum window downstream"
+		gvolume.color =  "aaaaff"
+		_make_full_tube(gvolume, r_in, r_out, foil_half_half_length)
+		gvolume.setPosition(0,0,z_center)
+		gvolume.material = "G4_Al"
+		return gvolume
 
-	# NH3Targ Cup Downstream Stream Window
-	z_center = -15
-	r_in = 0  # radius in mm
-	r_out = 10  # radius in mm
-	half_length = 0.025  # half length along beam axis
-	gvolume = GVolume("NH3CupDSWindow")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Upstream NH3 Target cup Downstream Window"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "aaaaaa"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_Al"
-	gvolume.publish(configuration)
+	def build_aluminum_exit_window():
+		# upstream al window
+		r_out = 13.5
+		r_in = 0.0
+		z_center = -half_half_length - foil_half_half_length	
+		gvolume = GVolume("al_window_exit")
+		gvolume.mother = "root"
+		gvolume.description = "25 mm thick aluminum window upstream"
+		gvolume.color =  "aaaaff"
+		_make_full_tube(gvolume, r_in, r_out, foil_half_half_length)
+		gvolume.setPosition(0,0,z_center)
+		gvolume.material = "G4_Al"
+		return gvolume
 
-	# NH3Targ
-	z_center = 25  # center location of target along beam axis
-	r_in = 0
-	r_out = 10  # radius in mm
-	half_length = 9.96  # half length along beam axis	
-	gvolume = GVolume("ND3Targ")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Downstream ND3 target cell"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "f000f0"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "ND3target"
-	gvolume.publish(configuration)
+	for builder in [
+		build_target_cell,
+		build_aluminum_entrance_window,
+		build_aluminum_exit_window
+	]:
+		volume = builder()
+		volume.publish(configuration)
 
-	# NH3Targ Cup
-	z_center = 25
-	r_in = 10.0001  # radius in mm
-	r_out = 10.03  # radius in mm
-	half_length = 9.75  # half length along beam axis
-	gvolume = GVolume("ND3Cup")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Downstream ND3 Target cup"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "ffffff"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "AmmoniaCellWalls"
-	gvolume.publish(configuration)
-
-	# ND3Targ Cup Down Stream Ring
-	z_center = 35
-	r_in = 10.0001  # radius in mm
-	r_out = 11.43  # radius in mm
-	half_length = 0.25  # half length along beam axis
-	gvolume = GVolume("ND3CupDSRing")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Downstream ND3 Target cup downstream Ring"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "ffffff"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "AmmoniaCellWalls"
-	gvolume.publish(configuration)
-
-	# ND3Targ Cup UP Stream Ring
-	z_center = 15
-	r_in = 10.0001  # radius in mm
-	r_out = 11.43  # radius in mm
-	half_length = 0.25  # half length along beam axis
-	gvolume = GVolume("ND3CupUSRing")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Downstrem ND3 Target cup Upstream Ring"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "ffffff"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "AmmoniaCellWalls"
-	gvolume.publish(configuration)
-
-	# ND3Targ Cup Window Frame
-	z_center = 15
-	r_in = 11.44  # radius in mm
-	r_out = 12.7  # radius in mm
-	half_length = 1.5875  # half length along beam axis
-	gvolume = GVolume("ND3CupWindowFrame_20")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Upstream NH3 Target cup Window frame"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "ffffff"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "AmmoniaCellWalls"
-	gvolume.publish(configuration)
-
-	# ND3Targ Cup Up Stream Window
-	z_center = 35
-	r_in = 0.0  # radius in mm
-	r_out = 10.0  # radius in mm
-	half_length = 0.025  # half length along beam axis	
-	gvolume = GVolume("ND3CupUSWindow_20")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Downstream ND3 Target cup Upstream Window"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "aaaaaa"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_Al"
-	gvolume.publish(configuration)
-
-	# ND3Targ Cup Downstream Stream Window
-	z_center = 15
-	r_in = 0.0  # radius in mm
-	r_out = 10.0  # radius in mm
-	half_length = 0.025  # half length along beam axis	
-	gvolume = GVolume("ND3CupDSWindow")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Downstream ND3 Target cup Downstream Window"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "aaaaaa"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_Al"
-	gvolume.publish(configuration)
-
-	# Insert Bath Entrance window part 7 a
-	z_center = -37.395
-	r_in = 0.0  # radius in mm
-	r_out = 11.5  # radius in mm
-	half_length = 0.605  # half length along beam axis
-	gvolume = GVolume("InsertBathEntranceWindow_7a")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Insert Bath Entrence window part 7 a"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "aaaaaa"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_Al"
-	gvolume.publish(configuration)
-
-	# Insert Bath Entrance window part 7 b
-	z_center = -68.2
-	r_in = 11.0  # radius in mm
-	r_out = 11.5  # radius in mm
-	half_length = 30.1  # half length along beam axis
-	gvolume = GVolume("InsertBathEntranceWindow_7b")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Insert Bath Entrence window part 7 b"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "aaaaaa"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_Al"
-	gvolume.publish(configuration)
-
-	# Insert Bath Entrance window part 7 c
-	z_center = -98.4
-	r_in = 11.5001  # radius in mm
-	r_out = 14.4  # radius in mm
-	half_length = 3.17  # half length along beam axis
-	gvolume = GVolume("InsertBathEntranceWindow_7c")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Insert Bath Entrence window part 7 c"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "aaaaaa"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_Al"
-	gvolume.publish(configuration)
-
-	# Insert Bath Entrance window part 7 d
-	z_center = -102.23
-	r_in = 11.0  # radius in mm
-	r_out = 14.96  # radius in mm
-	half_length = 0.66  # half length along beam axis
-	gvolume = GVolume("InsertBathEntranceWindow_7d")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Insert Bath Entrence window part 7 d"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "aaaaaa"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_Al"
-	gvolume.publish(configuration)
-	
-	# Shim Coil Carrier
-	z_center = -19.3
-	r_in = 28.8  # radius in mm
-	r_out = 29.3  # radius in mm
-	half_length = 80.95  # half length along beam axis	
-	gvolume = GVolume("ShimCoilCarrier")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Shim Coil Carrier"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "aaaaaa"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_Al"
-	gvolume.publish(configuration)
-
-	# Shim Up Up stream Coil
-	z_center = 43.5
-	r_in = 29.3  # radius in mm
-	r_out = 30.0  # radius in mm
-	half_length = 6.0  # half length along beam axis
-	gvolume = GVolume("ShimUpUpS")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Shim Coil Up Up stream Coil"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "a00000"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "ShimCoil"
-	gvolume.publish(configuration)
-
-	# Shim Up stream Coil
-	z_center = 8.5
-	r_in = 29.3  # radius in mm
-	r_out = 30.0  # radius in mm
-	half_length = 6.0  # half length along beam axis
-	gvolume = GVolume("ShimUpS")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Shim Coil Up stream"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "a00000"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "ShimCoil"
-	gvolume.publish(configuration)
-
-	# Shim Down stream Coil
-	z_center = -8.5
-	r_in = 29.3  # radius in mm
-	r_out = 30.0  # radius in mm
-	half_length = 6.0  # half length along beam axis
-	gvolume = GVolume("ShimDownS")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Shim Coil Down stream"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "a00000"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "ShimCoil"
-	gvolume.publish(configuration)
-
-	# Shim Down Down stream Coil
-	z_center = -43.5
-	r_in = 29.3  # radius in mm
-	r_out = 30.0  # radius in mm
-	half_length = 6.0  # half length along beam axis
-	gvolume = GVolume("ShimDownDownS")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "Shim Coil Down Down stream"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "a00000"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "ShimCoil"
-	gvolume.publish(configuration)
-	
-	# Heat Shield tube
-	z_center = -34.3
-	r_in = 40.3  # radius in mm
-	r_out = 41.3  # radius in mm
-	half_length = 83.85  # half length along beam axis
-	gvolume = GVolume("HeatShieldTube")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "PolTarg Heat Shield Tube"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "aaaaaa"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_Al"
-	gvolume.publish(configuration)
-
-	# Heat Shield Half Sphere
-	z_center = 49.55
-	r_in = 40.3  # radius in mm
-	r_out = 41.3  # radius in mm
-	gvolume = GVolume("HeatShieldSphere")
-	gvolume.mother = "PolTarg"
-	gvolume.description = "PolTarg Heat Shield Exit window Shere"
-	gvolume.setPosition(0,0,z_center)
-	gvolume.color = "aaaaaa"
-	gvolume.makeG4Sphere(r_in, r_out, 0, 360, 0, 90)
-	gvolume.material = "G4_Al"
-	gvolume.publish(configuration)
-
-def build_geometry_bonus(configuration):
-	# bonus root volume
-	r_in = 0.0 # radius in mm
-	r_out = 4  # radius in mm
-	half_length = 225.0  # half length along beam axis
-	gvolume = GVolume("bonusTarget")
-	gvolume.mother = "root"
-	gvolume.description = "BONuS12 RTPC gaseous D2 Target"
-	gvolume.color =  "eeeegg"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_He"
-	gvolume.visible = "0"
-	gvolume.publish(configuration)
-	
-	# bonus target gas volume
-	r_in = 0.0
-	r_out = 3.0
-	half_length = 223.0  # half length
-	gvolume = GVolume("gasDeuteriumTarget")
-	gvolume.mother = "bonusTarget"
-	gvolume.description = "7 atm deuterium target gas"
-	gvolume.color =  "a54382"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "bonusTargetGas"
-	gvolume.publish(configuration)
-	
-	# bonus target wall
-	r_in = 3.01
-	r_out = 3.056
-	half_length = 223.0  # half length
-	gvolume = GVolume("bonusTargetWall")
-	gvolume.mother = "bonusTarget"
-	gvolume.description = "Bonus Target wall"
-	gvolume.color =  "330099"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_KAPTON"
-	gvolume.publish(configuration)
-	
-	# bonus target downstream aluminum end cap ring
-	r_in = 3.0561
-	r_out = 3.1561
-	half_length = 2.0  # half length
-	z_center = 221  # z position
-	gvolume = GVolume("bonusTargetEndCapRing")
-	gvolume.mother = "bonusTarget"
-	gvolume.description = "Bonus Target Al end cap ring"
-	gvolume.color =  "000000"
-	gvolume.setPosition(0,0,z_center)
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_Al"
-	gvolume.publish(configuration)
-	
-	# bonus target downstream aluminum end cap ring
-	r_in = 0.0
-	r_out = 3.1561
-	half_length = 0.05  # half length
-	z_center = 223.06  # z position
-	gvolume = GVolume("bonusTargetEndCapPlate")
-	gvolume.mother = "bonusTarget"
-	gvolume.description = "Bonus Target Al end cap wall"
-	gvolume.color =  "000000"
-	gvolume.setPosition(0,0,z_center)
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_Al"
-	gvolume.publish(configuration)
-
-def build_geometry_pb_test(configuration):
-	# mother is a helium bag 293.26 mm long. Its center is 40.85 mm
-	z_shift = 40.85
-	r_in = 0.0
-	r_out = 10.0
-	cell_half_length = 293.26 / 2
-	z_center = cell_half_length - z_shift
-	gvolume = GVolume("targetCell")
-	gvolume.mother = "root"
-	gvolume.description ="Helium cell"
-	gvolume.color =  "5511111"
-	gvolume.setPosition(0,0,z_center)
-	_make_full_tube(gvolume, r_in, r_out, cell_half_length)
-	gvolume.material = "G4_He"
-	gvolume.publish(configuration)
-
-	# PB 125 microns
-	r_in = 0.0
-	r_out = 5.0
-	z_center = z_shift - cell_half_length
-	half_length = 0.0625 # (0.125 mm thick)
-	gvolume = GVolume("testPbTarget")
-	gvolume.mother = "targetCell"
-	gvolume.description ="Pb target"
-	gvolume.color =  "004488"
-	gvolume.setPosition(0,0,z_center)
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_Pb"
-	gvolume.publish(configuration)
-
-	# Upstream Foil 50 microns Aluminum at 24.8 cm
-	z_center = 0.1 - cell_half_length   # upstream end
-	r_in = 0.0
-	r_out = 5.0 
-	half_length = 0.015 # (0.030 mm thick)
-	gvolume = GVolume("AlTargetFoilUpstream")
-	gvolume.mother = "targetCell"
-	gvolume.description ="Aluminum Upstream Foil"
-	gvolume.color =  "aaaaaa"
-	gvolume.color =  "004488"
-	gvolume.setPosition(0,0,z_center)
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_Al"
-	gvolume.publish(configuration)
-
-	# Downstream Foil 50 microns Aluminum at 24.8 cm
-	z_center = cell_half_length - 0.1   # Downstream end
-	r_in = 0.0
-	r_out = 5.0
-	half_length = 0.015 # (0.030 mm thick)
-	gvolume = GVolume("AlTargetFoilDownstream")
-	gvolume.mother = "targetCell"
-	gvolume.description ="Aluminum Downstream Foil"
-	gvolume.color =  "aaaaaa"
-	gvolume.material = "G4_Al"
-	gvolume.setPosition(0,0,z_center)
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.publish(configuration)
-
-	# flux detector downstream of the scattering chamber
-	z_center = 300.0   
-	r_out = 45.0
-	half_length = 0.015 # (0.030 mm thick)
-	gvolume = GVolume("testFlux")
-	gvolume.mother = "root"
-	gvolume.description = "Flux detector"
-	gvolume.color = "009900"
-	gvolume.setPosition(0,0,z_center)
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material = "G4_AIR"
-	# gvolume.sensivity = "flux"
-	# gvolume.hit_type = "flux"
-	# gvolume.identifiers = "id manual 1"
-	gvolume.publish(configuration)
-
-def build_geometry_nd3(configuration):
+def build_geometry_apollo(configuration):
 
 	variation = configuration.variation
+	material_varmap = {
+		"apollo_nh3": "NH3target",
+		"apollo_nd3": "ND3target"
+	}
 
-	# vacuum container
-	r_in = 0.0
-	r_out= 44.0
-	half_lenght = 50.0  # half length
-	gvolume = GVolume("scatteringChamberVacuum")
-	gvolume.description = f'clas12 scattering chamber vacuum rohacell container for {variation} target'
-	gvolume.color = "aaaaaa4"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material  = "G4_Galactic"
-	gvolume.publish(configuration)
-	
-	# rohacell
-	r_in = 0.0
-	r_out = 43.0
-	half_length = 48.0  # half length
-	gvolume = GVolume("scatteringChamber")
-	gvolume.mother = "scatteringChamberVacuum"
-	gvolume.description = f'clas12 rohacell scattering chamber for {variation} target'
-	gvolume.color = "ee3344"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material  = "rohacell"
-	gvolume.publish(configuration)
-	
-	# vacuum container for plastic cell
-	r_in = 0.0
-	r_out = 40.0
-	half_length = 45.0  # half length
-	gvolume = GVolume("plasticCellVacuum")
-	gvolume.mother = "scatteringChamber"
-	gvolume.description = f'clas12 rohacell vacuum aluminum container chamber for {variation} target'
-	gvolume.color = "aaaaaa4"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material  = "G4_Galactic"
-	gvolume.publish(configuration)
-	
-	# helium cylinder
-	r_in = 0.0
-	r_out = 12.62
-	half_length = 25.10  # half length
-	gvolume = GVolume("HeliumCell")
-	gvolume.mother = "plasticCellVacuum"
-	gvolume.description = f'Helium volume for {variation} target'
-	gvolume.color = "aaaaaa3"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	#gvolume.material  = "G4_He"
-	gvolume.material  = "G4_Galactic" #temporaly replacing with vacuum. Maria: What should we do here?
-	gvolume.publish(configuration)
-	
-	# plastic cylinder cell
-	r_in = 0.0
-	r_out = 12.60
-	half_length = 20.10  # half length
-	gvolume = GVolume("plasticCell")
-	gvolume.mother = "HeliumCell"
-	gvolume.description = f'clas12 plastic cell for {variation} target'
-	gvolume.color = "aaaaaa"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material  = "G4_TEFLON" #using teflon which is similar to the actual cell
-	gvolume.publish(configuration)
-	
-	# actual target
-	r_in = 0.0
-	r_out = 12.50 # target has a 25mm diameter
-	half_length = 20.00  # half length (target is 4cm long)
-	gvolume = GVolume(f'{variation}')
-	gvolume.mother = "plasticCell"
-	gvolume.description = f'clas12 {variation} target'
-	gvolume.color = "ee8811Q"
-	_make_full_tube(gvolume, r_in, r_out, half_length)
-	gvolume.material  = "solidND3"
-	gvolume.publish(configuration)
+	name_varmap = {
+		"apollo_nh3": "NH3",
+		"apollo_nd3": "ND"
+	}
 
+	volume_length = 77.0
+	target_length = 50.0 #length of the NH3 target
+	target_radius = 10.0 #radius of the NH3 target
+	target_center = 0.0  #center of the NH3 target
+	target_window_thickness = 0.02
+	vacuum_radius = 51.0
+	beam_window_thickness = 0.13
+	bath_half_length = (target_length+target_window_thickness)/2
+	bath_wall_thickness = 0.25
+	bath_window_thickness = 0.13
+	bath_wall_z0 = target_length/2+target_window_thickness+4+bath_window_thickness    
+	bath_dx = 25.0/2
+	bath_dy = 45.0/2
+	bath_dz = (bath_wall_z0+volume_length)/2
+	bath_z0 = (bath_wall_z0-volume_length)/2
+	shim_coils_mandrel_r_in = 29.0 
+	shim_coils_mandrel_r_out = 29.25
+	shim_coils_length = 12.0
+	shim_coils_thickness = 0.7
+	shim_coils_window = 0.02
+	pumping_volume_r_in = 35.5
+	pumping_volume_r_out = 36.0
+	pumping_volume_window = 0.13
+	heat_shield_r_in = 40.75
+	heat_shield_r_out = 41.25
+	heat_shield_window = 0.02
+	vacuum_can_r_in = vacuum_radius - 1.0
+	vacuum_can_r_out = vacuum_radius
+	vacuum_can_window = 0.13
+	spheres_center = bath_wall_z0 + 3.0
+
+	def build_mother_volume():
+		# mother volume
+		r_out = vacuum_radius
+		z_length = spheres_center + vacuum_radius
+		n_planes = 2
+		phi_start = 0
+		phi_total = 360 
+		z_plane = [-volume_length, z_length]
+		outer_radius = [r_out]*n_planes
+		inner_radius = [0.0]*n_planes
+		gvolume = GVolume("PolTarg")
+		gvolume.description = "PolTarg Region"
+		gvolume.color = "123456"
+		gvolume.makeG4Polycone(phi_start, phi_total, n_planes, z_plane, inner_radius, outer_radius)
+		gvolume.material = "G4_AIR"
+		gvolume.visible = 0 
+		return gvolume
+
+	def build_vacuum_volume():
+		# vacuum volume
+		r_out = vacuum_radius
+		n_planes = 2
+		phi_start = 0
+		phi_total = 360 
+		z_plane = [-volume_length, spheres_center]
+		outer_radius = [r_out]*n_planes
+		inner_radius = [0.0]*n_planes
+		gvolume = GVolume("VacuumVolume")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Vacuum cylindrical volume"
+		gvolume.color = "ffffff"
+		gvolume.setPosition(0,0,target_center)
+		gvolume.makeG4Polycone(phi_start, phi_total, n_planes, z_plane, inner_radius, outer_radius)
+		gvolume.material = "G4_Galactic"
+		gvolume.visible = 0
+		return gvolume
+		
+	def build_vacuum_sphere():
+		# vacuum sphere
+		r_out = vacuum_radius
+		r_in = 0.0
+		phi_start = 0
+		dphi = 360
+		theta_start = 0
+		dtheta = 90
+		gvolume = GVolume("VacuumSphere")
+		gvolume.mother = "PolTarg"
+		gvolume.description = "Vacuum half sphere volume"
+		gvolume.setPosition(0,0,spheres_center)
+		gvolume.color = "ffffff"
+		gvolume.makeG4Sphere(r_in, r_out, phi_start, dphi, theta_start, dtheta)
+		gvolume.material = "G4_Galactic"
+		gvolume.visible = 0
+		return gvolume
+
+	def build_lhe_bath_walls():
+		#LHe bath walls
+		dx = bath_dx + bath_wall_thickness
+		dy = bath_dy + bath_wall_thickness
+		dz = bath_dz
+		gvolume = GVolume("HeliumBathWalls")
+		gvolume.mother = "VacuumVolume"
+		gvolume.description = "LHe bath walls"
+		gvolume.color = "aaaaaa"
+		gvolume.makeG4Box(dx, dy, dz)
+		gvolume.setPosition(0,0,bath_z0)
+		gvolume.material = "AmmoniaCellWalls"
+		return gvolume
+
+	def build_lhe_bath():	
+		#LHe bath
+		gvolume = GVolume("HeliumBath")
+		gvolume.mother = "HeliumBathWalls"
+		gvolume.description = "LHe bath"
+		gvolume.color = "0099ff"
+		gvolume.makeG4Box(bath_dx, bath_dy, bath_dz)
+		gvolume.setPosition(0,0,0)
+		gvolume.material = "lHeCoolant"
+		return gvolume
+		
+	def build_lhe_bath_window():
+		#LHe bath window
+		z_center = bath_dz - bath_window_thickness/2
+		dz = bath_window_thickness/2
+		gvolume = GVolume("HeliumBathWindow")
+		gvolume.mother = "HeliumBath"
+		gvolume.description = "LHe bath window"
+		gvolume.color = "aaaaaa"
+		gvolume.makeG4Box(bath_dx, bath_dy, dz)
+		gvolume.setPosition(0,0,z_center)
+		gvolume.material = "G4_Al"
+		return gvolume
+		
+	def build_target():
+		z_center = -bath_z0    # center location of target along beam axis
+		r_out = target_radius    # radius in mm
+		r_in = 0.0
+		half_length = target_length/2  # half length along beam axis
+		gvolume = GVolume(f'{name_varmap[variation]}Targ')
+		gvolume.mother = "HeliumBath"
+		gvolume.description = f'{name_varmap[variation]} target cell'
+		gvolume.setPosition(0,0,z_center)
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.color = "f000f0"
+		gvolume.material = material_varmap[variation]
+		return gvolume
+
+	def build_target_cup():
+		# Target Cup
+		r_in = target_radius + 0.001  # radius in mm
+		r_out = target_radius + 0.03   # radius in mm
+		half_length = target_length/2   # half length along beam axis
+		z_center = -bath_z0    # center location of target along beam axis
+		gvolume = GVolume("NH3Cup")
+		gvolume.mother = "HeliumBath"
+		gvolume.description = "NH3 Target cup"
+		gvolume.color = "ffffff"
+		gvolume.setPosition(0,0,z_center)
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "AmmoniaCellWalls"
+		return gvolume
+
+	def build_target_cup_upstream_window():
+		# Target Cup Up Stream Window
+		z_center = -bath_z0-target_length/2-target_window_thickness/2
+		r_in = 0.0 # radius in mm
+		r_out = target_radius # radius in mm
+		half_length = target_window_thickness/2 # half length along beam axis
+		gvolume = GVolume("NH3USWindow")
+		gvolume.mother = "HeliumBath"
+		gvolume.description = "NH3 Target cup Upstream Window"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "aaaaaa"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	def build_target_cup_downstream_window():
+		# Target Cup Downstream Stream Window
+		z_center = -bath_z0+target_length/2+target_window_thickness/2
+		r_in = 0.0 # radius in mm
+		r_out = target_radius # radius in mm
+		half_length = target_window_thickness/2  # half length along beam axis
+		gvolume = GVolume("NH3DSWindow")
+		gvolume.mother = "HeliumBath"
+		gvolume.description = "NH3 Target cup Downstream Window"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "aaaaaa"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	def build_beam_pipe():
+		# Beam pipe
+		r_in  = 0
+		r_out = target_radius+1
+		z1 = -bath_dz
+		z2 = -bath_z0-target_length/2-target_window_thickness
+		half_length = (z2-z1)/2
+		z_center     = (z2+z1)/2
+		gvolume = GVolume("BeamEntranceVacuum")
+		gvolume.mother = "HeliumBath"
+		gvolume.description = "Beam Entrance Vacuum"
+		gvolume.color = "ffffff"
+		gvolume.setPosition(0,0,z_center)
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Galactic"
+		return gvolume
+
+	def build_beam_entrance_pipe():
+		r_in  = target_radius+1
+		r_out = target_radius+2
+		z1 = -bath_dz
+		z2 = -bath_z0-target_length/2-target_window_thickness
+		half_length = (z2-z1)/2
+		z_center     = (z2+z1)/2
+		gvolume = GVolume("BeamEntrancePipe")
+		gvolume.mother = "HeliumBath"
+		gvolume.description = "Beam Entrance Pipe"
+		gvolume.color = "595959"
+		gvolume.setPosition(0,0,z_center)
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	def build_beam_entrance_window():
+		#  Beam Entrance Window
+		z1 = -bath_dz
+		z2 = -bath_z0-target_length/2-target_window_thickness
+		z_half_length = (z2-z1)/2
+		z_center = z_half_length-beam_window_thickness/2
+		r_in = 0.0      # radius in mm
+		r_out = target_radius+1    # radius in mm
+		half_length = beam_window_thickness/2  # half length along beam axis
+		gvolume = GVolume("BeamEntrance")
+		gvolume.mother = "BeamEntranceVacuum"
+		gvolume.description = "Beam entrance window"
+		gvolume.setPosition(0,0,z_center)
+		gvolume.color = "aaaaaa"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "G4_Al"
+		return gvolume
+
+	def build_shim_up_upstream_coil():
+		return _create_shimcoil(bath_half_length - shim_coils_length / 2, 1)
+
+	def build_shim_upstream_coil():
+		return _create_shimcoil(-4.5, 2)
+
+	def build_shim_downstream_coil():
+		return _create_shimcoil(-22.5, 3)
+
+	def build_shim_coil_carrier():
+		yield from _create_spheretube_volumes(
+			shim_coils_mandrel_r_in,
+			shim_coils_mandrel_r_out,
+			shim_coils_window,
+			"ShimCoil",
+			"G4_Al",
+			"aaaaaa"
+		)
+
+	def build_pumping_volume():
+		yield from _create_spheretube_volumes(
+			pumping_volume_r_in,
+			pumping_volume_r_out,
+			pumping_volume_window,
+			"PumpingVolume",
+			"G4_Al",
+			"000080"
+		)
+
+	def build_heat_shield_volume():
+		yield from _create_spheretube_volumes(
+			heat_shield_r_in,
+			heat_shield_r_out,
+			heat_shield_window,
+			# @mariakzurek: should this be "HeatShield"?
+			"HeathShield",
+			"G4_Al",
+			"404040",
+		)
+
+	def build_vacuum_can():
+		yield from _create_spheretube_volumes(
+			vacuum_can_r_in,
+			vacuum_can_r_out,
+			vacuum_can_window,
+			"VacuumCan",
+			"G4_Al",
+			"0d0d0d"
+		)
+
+	def _create_spheretube_volumes(
+		r_in,
+		r_out,
+		r_win,
+		name,
+		mat,
+		color,
+	):
+		tube = GVolume(f"{name}Tube")
+		tube.mother = "VacuumVolume"
+		tube.description = f"{name} tube"
+		tube.makeG4Polycone(
+			0.,
+			360.,
+			2,
+			[volume_length, spheres_center],
+			[r_in, r_in],
+			[r_out, r_out],
+		)
+
+		theta = int(math.atan((target_radius + 1) / r_in) * 180 / math.pi) + 1
+		dtheta = 90 - theta
+		sphere = GVolume(f"{name}Sphere")
+		sphere.mother = "VacuumSphere"
+		sphere.description = f"{name} sphere"
+
+		sphere.makeG4Sphere(
+			r_in,
+			r_out,
+			0.,
+			360.,
+			theta,
+			dtheta,
+		)
+		r_out_window = r_in + r_win
+		window = GVolume(f"{name}Window")
+		window.description = f"{name} window"
+		window.mother = "VacuumSphere"
+		window.makeG4Sphere(
+			r_in,
+			r_out_window,
+			0.,
+			360.,
+			0.,
+			theta
+		)
+
+		for volume in [
+			tube,
+			sphere,
+			window
+		]:
+			volume.material = mat
+			volume.color = color
+			yield volume
+
+	def _create_shimcoil(
+		z_center,
+		num,
+	):
+		r_in = shim_coils_mandrel_r_out
+		r_out = shim_coils_mandrel_r_out + shim_coils_thickness
+	
+		half_length = shim_coils_length / 2
+		gvolume = GVolume(f"ShimCoil{num}")
+		gvolume.mother = "VacuumVolume"
+		gvolume.description = f"Shim Coil {num}"
+		gvolume.setPosition(0, 0, z_center)
+		gvolume.color = "a00000"
+		_make_full_tube(gvolume, r_in, r_out, half_length)
+		gvolume.material = "ShimCoil"
+		return gvolume
+
+	volumes_to_publish = []
+	for builder in [
+		build_mother_volume,
+		build_vacuum_volume,
+		build_vacuum_sphere,
+		build_lhe_bath_walls,
+		build_lhe_bath,
+		build_lhe_bath_window,
+		build_target,
+		build_target_cup,
+		build_target_cup_upstream_window,
+		build_target_cup_downstream_window,
+		build_beam_pipe,
+		build_beam_entrance_pipe,
+		build_beam_entrance_window,
+		build_shim_up_upstream_coil,
+		build_shim_upstream_coil,
+		build_shim_downstream_coil,
+	]:
+		volumes_to_publish.append(builder())
+	for multi_volume_builder in [
+		# these builder functions return multiple volumes
+		build_shim_coil_carrier,
+		build_pumping_volume,
+		build_heat_shield_volume,
+		build_vacuum_can,
+	]:
+		volumes_to_publish.extend(multi_volume_builder())
+
+	for volume in volumes_to_publish:
+		volume.publish(configuration)
+
+
+	
 VARIATION_MAP = {
 	"lh2": build_geometry_lhydrogen,
 	"lh2e": build_geometry_lhydrogen,
 	"ld2": build_geometry_lhydrogen,
-	"c12": build_geometry_c12,
 	"pol_targ": build_geometry_pol_targ,
 	"bonus": build_geometry_bonus,
-	"pb_test": build_geometry_pb_test
+	"pb_test": build_geometry_pb_test,
+	"nd3": build_geometry_nd3,
+
+	"c12": build_geometry_c12,
+	"sn118" : build_geometry_sn118,
+	"pb208" : build_geometry_pb208,
+	"cu63" : build_geometry_cu63,
+	"al27" : build_geometry_al27,
+
+	"hdice" : build_geometry_hdice,
+	"longitudinal" : build_geometry_longitudinal,
+	"transverse" : build_geometry_transverse,
+	"apollo_nh3": build_geometry_apollo,
+	"apollo_nd3": build_geometry_apollo,
 }

--- a/projects/clas12/targets/geometry.py
+++ b/projects/clas12/targets/geometry.py
@@ -352,7 +352,7 @@ def build_geometry_pol_targ(configuration):
 		gvolume.material = "G4_Al"
 		return gvolume
 
-	def build_bath_entrance_window_part_7c():
+	def build_bath_entrance_window_part_7d():
 		z_center = -102.23
 		r_in = 11.0  # radius in mm
 		r_out = 14.96  # radius in mm
@@ -483,7 +483,7 @@ def build_geometry_pol_targ(configuration):
 		build_bath_entrance_window_part_7a,
 		build_bath_entrance_window_part_7b,
 		build_bath_entrance_window_part_7c,
-		build_bath_entrance_window_part_7c,
+		build_bath_entrance_window_part_7d,
 		build_shim_coil_carrier,
 		build_shim_up_upstream_coil,
 		build_shim_upstream_coil,

--- a/projects/clas12/targets/materials.py
+++ b/projects/clas12/targets/materials.py
@@ -162,17 +162,6 @@ def define_materials(configuration):
 	gmaterial.addMaterialWithFractionalMass('G4_F', F_mass_fraction)
 	gmaterial.publish(configuration)
 
-	# ND3, not sure if G4 has H2 material so used H for now
-	ND3_density = 1.007
-	N_mass_fraction=15/21
-	H2_mass_fraction=6/21
-	gmaterial = GMaterial('ND3')
-	gmaterial.description = 'ND3 material'
-	gmaterial.density =  ND3_density 
-	gmaterial.addMaterialWithFractionalMass('G4_N', N_mass_fraction)
-	gmaterial.addMaterialWithFractionalMass('G4_H', H2_mass_fraction)
-	gmaterial.publish(configuration)
-
 	# ND3 target with lHe3 coolant
 	ND3targ_density = 0.6*1.007+0.4*0.145 # 60% of ND3 and 40% of liquid-helium
 	ND3_mass_fraction=0.6*1.007/ND3targ_density

--- a/projects/clas12/targets/materials.py
+++ b/projects/clas12/targets/materials.py
@@ -98,7 +98,8 @@ def define_materials(configuration):
 	# lHe coolant
 	gmaterial = GMaterial('lHeCoolant')
 	gmaterial.description = 'liquid He coolant for the polarized target cell'
-	gmaterial.density = 0.147  # 0.145 g/cm3  #Maria: Should it be 145 or 147??????
+	# @mariakzurek: Should it be 145 or 147??????
+	gmaterial.density = 0.147  # 0.145 g/cm3  
 	gmaterial.addMaterialWithFractionalMass('G4_He', 1)
 	gmaterial.publish(configuration)
 
@@ -163,7 +164,7 @@ def define_materials(configuration):
 	gmaterial.publish(configuration)
 
 	# Target cup walls with holes, need to confirm mass ratios
-	# Maria: Do we need it? It is the same as Kel-F. Who is the author of the comment above?
+	# @mariakzurek: Do we need it? It is the same as Kel-F. Who is the author of the comment above?
 	my_density = 2.135 # 2 C, 3 F, 1 Cl
 	C_mass_fraction=2*12/(2*12+3*19+35)
 	F_mass_fraction=3*19/(2*12+3*19+35)
@@ -177,7 +178,7 @@ def define_materials(configuration):
 	gmaterial.publish(configuration)
 
 	# ND3, not sure if G4 has H2 material so used H for now
-	# Maria: What to do with the comment above? This target is using G4_H
+	# @mariakzurek: What to do with the comment above? This target is using G4_H
 	ND3_density = 1.007
 	N_mass_fraction=15/21
 	H2_mass_fraction=6/21

--- a/projects/clas12/targets/materials.py
+++ b/projects/clas12/targets/materials.py
@@ -220,4 +220,4 @@ def define_materials(configuration):
 	gmaterial = GMaterial('bonusTargetGas')
 	gmaterial.description = '7 atm deuterium gas'
 	gmaterial.density =  0.00126  # in g/cm3
-	gmaterial.addMaterialWithFractionalMass('deuteriumGas',1)
+	gmaterial.addMaterialWithFractionalMass('DeuteriumGas',1)

--- a/projects/clas12/targets/materials.py
+++ b/projects/clas12/targets/materials.py
@@ -64,19 +64,6 @@ def define_materials(configuration):
 	gmaterial.addMaterialWithFractionalMass('G4_B', B_mass_fraction)
 	gmaterial.publish(configuration)
 
-	#CTFE = C_2ClF_3
-	my_density = 2.135 # 2 C, 3 F, 1 Cl
-	C_mass_fraction=2*12/(2*12+3*19+35)
-	F_mass_fraction=3*19/(2*12+3*19+35)
-	Cl_mass_fraction=35/(2*12+3*19+35)
-	gmaterial = GMaterial('Kel-F')
-	gmaterial.description = 'Kel-F PCTFE target walls C_2ClF_3'
-	gmaterial.density = my_density
-	gmaterial.addMaterialWithFractionalMass('G4_C', C_mass_fraction)
-	gmaterial.addMaterialWithFractionalMass('G4_Cl', Cl_mass_fraction)
-	gmaterial.addMaterialWithFractionalMass('G4_F', F_mass_fraction)
-	gmaterial.publish(configuration)
-
 	#Alloy of Cu-Ni
 	my_density = 8.95
 	Cu_mass_fraction=0.7
@@ -98,8 +85,7 @@ def define_materials(configuration):
 	# lHe coolant
 	gmaterial = GMaterial('lHeCoolant')
 	gmaterial.description = 'liquid He coolant for the polarized target cell'
-	# @mariakzurek: Should it be 145 or 147??????
-	gmaterial.density = 0.147  # 0.145 g/cm3  
+	gmaterial.density = 0.146  
 	gmaterial.addMaterialWithFractionalMass('G4_He', 1)
 	gmaterial.publish(configuration)
 
@@ -164,7 +150,6 @@ def define_materials(configuration):
 	gmaterial.publish(configuration)
 
 	# Target cup walls with holes, need to confirm mass ratios
-	# @mariakzurek: Do we need it? It is the same as Kel-F. Who is the author of the comment above?
 	my_density = 2.135 # 2 C, 3 F, 1 Cl
 	C_mass_fraction=2*12/(2*12+3*19+35)
 	F_mass_fraction=3*19/(2*12+3*19+35)
@@ -178,7 +163,6 @@ def define_materials(configuration):
 	gmaterial.publish(configuration)
 
 	# ND3, not sure if G4 has H2 material so used H for now
-	# @mariakzurek: What to do with the comment above? This target is using G4_H
 	ND3_density = 1.007
 	N_mass_fraction=15/21
 	H2_mass_fraction=6/21

--- a/projects/clas12/targets/materials.py
+++ b/projects/clas12/targets/materials.py
@@ -1,0 +1,222 @@
+from gemc_api_materials import *
+
+def define_materials(configuration):
+
+	# rohacell
+	gmaterial = GMaterial('rohacell')
+	gmaterial.description = 'target rohacell scattering chamber material'
+	gmaterial.density = 0.1 #100 mg/cm3
+	gmaterial.addMaterialWithFractionalMass('G4_C', 0.6465)
+	gmaterial.addMaterialWithFractionalMass('G4_H', 0.0784)
+	gmaterial.addMaterialWithFractionalMass('G4_N', 0.0839)
+	gmaterial.addMaterialWithFractionalMass('G4_O', 0.1912)
+	gmaterial.publish(configuration)
+
+	# epoxy
+	gmaterial = GMaterial('epoxy')
+	gmaterial.description = 'epoxy glue 1.16 g/cm3'
+	gmaterial.density = 1.16
+	gmaterial.addNAtoms('H', 32)
+	gmaterial.addNAtoms('N', 2)
+	gmaterial.addNAtoms('O', 4)
+	gmaterial.addNAtoms('C', 15)
+	gmaterial.publish(configuration)
+
+	# carbon_fiber
+	gmaterial = GMaterial('carbonFiber')
+	gmaterial.description = 'carbon fiber material is epoxy and carbon - 1.75g/cm3'
+	gmaterial.density = 1.75
+	gmaterial.addMaterialWithFractionalMass('G4_C', 0.745)
+	gmaterial.addMaterialWithFractionalMass('epoxy', 0.255)
+	gmaterial.publish(configuration)
+
+	# HDIce
+	H_atomic_weight = 1.00784
+	D_atomic_weight = 2.014
+	H_mass_fraction = H_atomic_weight/(H_atomic_weight+D_atomic_weight)
+	D_mass_fraction = D_atomic_weight/(H_atomic_weight+D_atomic_weight)
+	gmaterial = GMaterial('HDIce')
+	gmaterial.description = 'solid HD ice'
+	gmaterial.density = 0.147
+	gmaterial.addMaterialWithFractionalMass('G4_H', H_mass_fraction)
+	gmaterial.addMaterialWithFractionalMass('deuteriumGas', D_mass_fraction)
+	gmaterial.publish(configuration)
+
+	#HDIce+Al
+	HD_mass_fraction = 1 - (0.175-0.147)/(2.7-0.147)
+	Al_mass_fraction = (0.175-0.147)/(2.7-0.147)
+	gmaterial = GMaterial('solidHD')
+	gmaterial.description = 'solidHD target material - HDIce + Al'
+	gmaterial.density =0.175
+	gmaterial.addMaterialWithFractionalMass('HDIce', HD_mass_fraction)
+	gmaterial.addMaterialWithFractionalMass('G4_Al', Al_mass_fraction)
+	gmaterial.publish(configuration)
+
+	#MgB2
+	Mg_atomic_weight = 24.305
+	B_atomic_weight = 10.811
+	Mg_mass_fraction = Mg_atomic_weight/(Mg_atomic_weight+2*B_atomic_weight)
+	B_mass_fraction = 2*B_atomic_weight/(Mg_atomic_weight+2*B_atomic_weight)
+	gmaterial = GMaterial('MgB2')
+	gmaterial.description = 'MgB2'
+	gmaterial.density = 2.57
+	gmaterial.addMaterialWithFractionalMass('G4_Mg', Mg_mass_fraction)
+	gmaterial.addMaterialWithFractionalMass('G4_B', B_mass_fraction)
+	gmaterial.publish(configuration)
+
+	#CTFE = C_2ClF_3
+	my_density = 2.135 # 2 C, 3 F, 1 Cl
+	C_mass_fraction=2*12/(2*12+3*19+35)
+	F_mass_fraction=3*19/(2*12+3*19+35)
+	Cl_mass_fraction=35/(2*12+3*19+35)
+	gmaterial = GMaterial('Kel-F')
+	gmaterial.description = 'Kel-F PCTFE target walls C_2ClF_3'
+	gmaterial.density = my_density
+	gmaterial.addMaterialWithFractionalMass('G4_C', C_mass_fraction)
+	gmaterial.addMaterialWithFractionalMass('G4_Cl', Cl_mass_fraction)
+	gmaterial.addMaterialWithFractionalMass('G4_F', F_mass_fraction)
+	gmaterial.publish(configuration)
+
+	#Alloy of Cu-Ni
+	my_density = 8.95
+	Cu_mass_fraction=0.7
+	Ni_mass_fraction=0.3
+	gmaterial = GMaterial('Cu70Ni30')
+	gmaterial.description = 'Cupronickel 70-30'
+	gmaterial.density = my_density
+	gmaterial.addMaterialWithFractionalMass('G4_Cu', Cu_mass_fraction)
+	gmaterial.addMaterialWithFractionalMass('G4_Ni', Ni_mass_fraction)
+	gmaterial.publish(configuration)	
+
+	#Polarized He3 (longitudinal target)
+	gmaterial = GMaterial('polarizedHe3')
+	gmaterial.description = 'polarizedHe3 target material'
+	gmaterial.density = 0.000748
+	gmaterial.addMaterialWithFractionalMass('helium3Gas', 1)
+	gmaterial.publish(configuration)
+
+	# lHe coolant
+	gmaterial = GMaterial('lHeCoolant')
+	gmaterial.description = 'liquid He coolant for the polarized target cell'
+	gmaterial.density = 0.147  # 0.145 g/cm3  #Maria: Should it be 145 or 147??????
+	gmaterial.addMaterialWithFractionalMass('G4_He', 1)
+	gmaterial.publish(configuration)
+
+	# NH3
+	NH3_density = 0.867
+	N_mass_fraction=15/18
+	H_mass_fraction=3/18
+	gmaterial = GMaterial('NH3')
+	gmaterial.description = 'NH3 material'
+	gmaterial.density = NH3_density 
+	gmaterial.addMaterialWithFractionalMass('G4_N', N_mass_fraction)
+	gmaterial.addMaterialWithFractionalMass('G4_H', H_mass_fraction)
+	gmaterial.publish(configuration)
+
+	# NH3 target with lHe3 coolant
+	NH3trg_density = 0.6*0.867+0.4*0.145 # 60% of NH3 and 40% of liquid-helium
+	NH3_mass_fraction=0.6*0.867/NH3trg_density 
+	lHe_mass_fraction=0.4*0.145/NH3trg_density 
+	gmaterial = GMaterial('NH3target')
+	gmaterial.description = 'solid NH3 target material'
+	gmaterial.density =  NH3trg_density
+	gmaterial.addMaterialWithFractionalMass('NH3', NH3_mass_fraction)
+	gmaterial.addMaterialWithFractionalMass('lHeCoolant', lHe_mass_fraction)
+	gmaterial.publish(configuration)
+
+	# G10 fiberglass
+	gmaterial = GMaterial('G10')
+	gmaterial.description = 'G10 - 1.70 g/cm3'
+	gmaterial.density =  1.70
+	gmaterial.addMaterialWithFractionalMass('G4_Si', 0.283)
+	gmaterial.addMaterialWithFractionalMass('G4_O', 0.323)
+	gmaterial.addMaterialWithFractionalMass('G4_C', 0.364)
+	gmaterial.addMaterialWithFractionalMass('G4_H', 0.030)
+	gmaterial.publish(configuration)
+
+	# lHe gas
+	gmaterial = GMaterial('HeGas')
+	gmaterial.description = 'Upstream He gas'
+	gmaterial.density =  0.000164  # 0.164 kg/m3 
+	gmaterial.addMaterialWithFractionalMass('G4_He', 1)
+	gmaterial.publish(configuration)
+
+	# Al target cell(s)
+	gmaterial = GMaterial('AlCell')
+	gmaterial.description = 'Aluminum for target cells '
+	gmaterial.density =  2.70  # 2.7 g/cm3 
+	gmaterial.addMaterialWithFractionalMass('G4_Al', 1)
+	gmaterial.publish(configuration)
+
+	# Shim coils, need to confirm mass fractions and density
+	NbTi_density=6.63
+	ShimCoil_density=(1.3*8.96+NbTi_density)/2.3
+	Cu_mass_fraction=29/(29+41+22)
+	Nb_mass_fraction=41/(29+41+22)
+	Ti_mass_fraction=22/(29+41+22)
+	gmaterial = GMaterial('ShimCoil')
+	gmaterial.description = 'Cu/NbTi correction coils ratio is 1.3 Cu  to 1 NbTi'
+	gmaterial.density =  ShimCoil_density  #Cu=8.96 g/cm3 NbTi= 4.5 g/cm3 = Nb-47.5 wt % Ti 47.5% of the materials weight is Nb 
+	gmaterial.addMaterialWithFractionalMass('G4_Cu', Cu_mass_fraction)
+	gmaterial.addMaterialWithFractionalMass('G4_Nb', Nb_mass_fraction)
+	gmaterial.addMaterialWithFractionalMass('G4_Ti', Ti_mass_fraction)
+	gmaterial.publish(configuration)
+
+	# Target cup walls with holes, need to confirm mass ratios
+	# Maria: Do we need it? It is the same as Kel-F. Who is the author of the comment above?
+	my_density = 2.135 # 2 C, 3 F, 1 Cl
+	C_mass_fraction=2*12/(2*12+3*19+35)
+	F_mass_fraction=3*19/(2*12+3*19+35)
+	Cl_mass_fraction=35/(2*12+3*19+35)
+	gmaterial = GMaterial('AmmoniaCellWalls')
+	gmaterial.description = 'PCTFE target cell walls with holes C_2ClF_3'
+	gmaterial.density =  my_density  #2.10-2.17 g/cm3  has a dipole moment 
+	gmaterial.addMaterialWithFractionalMass('G4_C', C_mass_fraction)
+	gmaterial.addMaterialWithFractionalMass('G4_Cl', Cl_mass_fraction)
+	gmaterial.addMaterialWithFractionalMass('G4_F', F_mass_fraction)
+	gmaterial.publish(configuration)
+
+	# ND3, not sure if G4 has H2 material so used H for now
+	# Maria: What to do with the comment above? This target is using G4_H
+	ND3_density = 1.007
+	N_mass_fraction=15/21
+	H2_mass_fraction=6/21
+	gmaterial = GMaterial('ND3')
+	gmaterial.description = 'ND3 material'
+	gmaterial.density =  ND3_density 
+	gmaterial.addMaterialWithFractionalMass('G4_N', N_mass_fraction)
+	gmaterial.addMaterialWithFractionalMass('G4_H', H2_mass_fraction)
+	gmaterial.publish(configuration)
+
+	# ND3 target with lHe3 coolant
+	ND3targ_density = 0.6*1.007+0.4*0.145 # 60% of ND3 and 40% of liquid-helium
+	ND3_mass_fraction=0.6*1.007/ND3targ_density
+	lHe_mass_fraction=0.4*0.145/ND3targ_density
+	gmaterial = GMaterial('ND3target')
+	gmaterial.description = 'solid ND3 target'
+	gmaterial.density =  ND3targ_density
+	gmaterial.addMaterialWithFractionalMass('ND3', ND3_mass_fraction)
+	gmaterial.addMaterialWithFractionalMass('lHeCoolant', lHe_mass_fraction)
+	gmaterial.publish(configuration)
+
+	#liquid helium 0.145 g/cm3
+	gmaterial = GMaterial('lHe')
+	gmaterial.description = 'liquid helium'
+	gmaterial.density =  0.145  # 0.145 g/cm3 
+	gmaterial.addMaterialWithFractionalMass('G4_He',1)
+	
+	#solid ND3 target
+	my_density = 0.6*1.007+0.4*0.145 # 60% of ND3 and 40% of liquid-helium
+	ND3_mass_fraction=0.6*1.007/my_density
+	lHe_mass_fraction=0.4*0.145/my_density
+	gmaterial = GMaterial('solidND3')
+	gmaterial.description = 'solid ND3 target'
+	gmaterial.density =  my_density
+	gmaterial.addMaterialWithFractionalMass('ND3',ND3_mass_fraction)
+	gmaterial.addMaterialWithFractionalMass('lHe',lHe_mass_fraction)
+
+	# TargetbonusGas
+	gmaterial = GMaterial('bonusTargetGas')
+	gmaterial.description = '7 atm deuterium gas'
+	gmaterial.density =  0.00126  # in g/cm3
+	gmaterial.addMaterialWithFractionalMass('deuteriumGas',1)

--- a/projects/clas12/targets/materials.py
+++ b/projects/clas12/targets/materials.py
@@ -39,7 +39,7 @@ def define_materials(configuration):
 	gmaterial.description = 'solid HD ice'
 	gmaterial.density = 0.147
 	gmaterial.addMaterialWithFractionalMass('G4_H', H_mass_fraction)
-	gmaterial.addMaterialWithFractionalMass('deuteriumGas', D_mass_fraction)
+	gmaterial.addMaterialWithFractionalMass('DeuteriumGas', D_mass_fraction)
 	gmaterial.publish(configuration)
 
 	#HDIce+Al
@@ -92,7 +92,7 @@ def define_materials(configuration):
 	gmaterial = GMaterial('polarizedHe3')
 	gmaterial.description = 'polarizedHe3 target material'
 	gmaterial.density = 0.000748
-	gmaterial.addMaterialWithFractionalMass('helium3Gas', 1)
+	gmaterial.addMaterialWithFractionalMass('Helium3Gas', 1)
 	gmaterial.publish(configuration)
 
 	# lHe coolant

--- a/projects/clas12/targets/materials.py
+++ b/projects/clas12/targets/materials.py
@@ -116,7 +116,7 @@ def define_materials(configuration):
 	# NH3 target with lHe3 coolant
 	NH3trg_density = 0.6*0.867+0.4*0.145 # 60% of NH3 and 40% of liquid-helium
 	NH3_mass_fraction=0.6*0.867/NH3trg_density 
-	lHe_mass_fraction=0.4*0.145/NH3trg_density 
+	lHe_mass_fraction=0.4*0.145/NH3trg_density
 	gmaterial = GMaterial('NH3target')
 	gmaterial.description = 'solid NH3 target material'
 	gmaterial.density =  NH3trg_density

--- a/projects/clas12/targets/materials.py
+++ b/projects/clas12/targets/materials.py
@@ -205,6 +205,7 @@ def define_materials(configuration):
 	gmaterial.description = 'liquid helium'
 	gmaterial.density =  0.145  # 0.145 g/cm3 
 	gmaterial.addMaterialWithFractionalMass('G4_He',1)
+	gmaterial.publish(configuration)
 	
 	#solid ND3 target
 	my_density = 0.6*1.007+0.4*0.145 # 60% of ND3 and 40% of liquid-helium
@@ -215,9 +216,11 @@ def define_materials(configuration):
 	gmaterial.density =  my_density
 	gmaterial.addMaterialWithFractionalMass('ND3',ND3_mass_fraction)
 	gmaterial.addMaterialWithFractionalMass('lHe',lHe_mass_fraction)
+	gmaterial.publish(configuration)
 
 	# TargetbonusGas
 	gmaterial = GMaterial('bonusTargetGas')
 	gmaterial.description = '7 atm deuterium gas'
 	gmaterial.density =  0.00126  # in g/cm3
 	gmaterial.addMaterialWithFractionalMass('DeuteriumGas',1)
+	gmaterial.publish(configuration)

--- a/projects/clas12/targets/target_al27.jcard
+++ b/projects/clas12/targets/target_al27.jcard
@@ -1,0 +1,25 @@
+{
+	# number of threads
+	# The checkOverlaps = 2 options cause random crash when nthreads is > 1,
+	# possibly due to geometry asked by the run manager to delete objects while in use.
+	# This is an issue open on sci-g until new geant4 versions can be checked.
+	"nthreads": 1,
+
+	# verbosities
+	"verbosity": 1,
+	"gsystemv": 0,
+	"g4systemv": 0,
+
+	# the target system
+	"+gsystem": [
+		{
+			"system":   "./clas12Target",
+			"factory": "text",
+			"variation": "al27"
+		}
+	],
+
+	"n": 100,
+	"checkOverlaps": 2
+
+}

--- a/projects/clas12/targets/target_apollo_nd3.jcard
+++ b/projects/clas12/targets/target_apollo_nd3.jcard
@@ -1,0 +1,25 @@
+{
+	# number of threads
+	# The checkOverlaps = 2 options cause random crash when nthreads is > 1,
+	# possibly due to geometry asked by the run manager to delete objects while in use.
+	# This is an issue open on sci-g until new geant4 versions can be checked.
+	"nthreads": 1,
+
+	# verbosities
+	"verbosity": 1,
+	"gsystemv": 0,
+	"g4systemv": 0,
+
+	# the target system
+	"+gsystem": [
+		{
+			"system":   "./clas12Target",
+			"factory": "text",
+			"variation": "apollo_nd3"
+		}
+	],
+
+	"n": 100,
+	"checkOverlaps": 2
+
+}

--- a/projects/clas12/targets/target_apollo_nh3.jcard
+++ b/projects/clas12/targets/target_apollo_nh3.jcard
@@ -1,0 +1,25 @@
+{
+	# number of threads
+	# The checkOverlaps = 2 options cause random crash when nthreads is > 1,
+	# possibly due to geometry asked by the run manager to delete objects while in use.
+	# This is an issue open on sci-g until new geant4 versions can be checked.
+	"nthreads": 1,
+
+	# verbosities
+	"verbosity": 1,
+	"gsystemv": 0,
+	"g4systemv": 0,
+
+	# the target system
+	"+gsystem": [
+		{
+			"system":   "./clas12Target",
+			"factory": "text",
+			"variation": "apollo_nh3"
+		}
+	],
+
+	"n": 100,
+	"checkOverlaps": 2
+
+}

--- a/projects/clas12/targets/target_bonus.jcard
+++ b/projects/clas12/targets/target_bonus.jcard
@@ -1,0 +1,25 @@
+{
+	# number of threads
+	# The checkOverlaps = 2 options cause random crash when nthreads is > 1,
+	# possibly due to geometry asked by the run manager to delete objects while in use.
+	# This is an issue open on sci-g until new geant4 versions can be checked.
+	"nthreads": 1,
+
+	# verbosities
+	"verbosity": 1,
+	"gsystemv": 0,
+	"g4systemv": 0,
+
+	# the target system
+	"+gsystem": [
+		{
+			"system":   "./clas12Target",
+			"factory": "text",
+			"variation": "bonus"
+		}
+	],
+
+	"n": 100,
+	"checkOverlaps": 2
+
+}

--- a/projects/clas12/targets/target_cu63.jcard
+++ b/projects/clas12/targets/target_cu63.jcard
@@ -1,0 +1,25 @@
+{
+	# number of threads
+	# The checkOverlaps = 2 options cause random crash when nthreads is > 1,
+	# possibly due to geometry asked by the run manager to delete objects while in use.
+	# This is an issue open on sci-g until new geant4 versions can be checked.
+	"nthreads": 1,
+
+	# verbosities
+	"verbosity": 1,
+	"gsystemv": 0,
+	"g4systemv": 0,
+
+	# the target system
+	"+gsystem": [
+		{
+			"system":   "./clas12Target",
+			"factory": "text",
+			"variation": "cu63"
+		}
+	],
+
+	"n": 100,
+	"checkOverlaps": 2
+
+}

--- a/projects/clas12/targets/target_hdice.jcard
+++ b/projects/clas12/targets/target_hdice.jcard
@@ -1,0 +1,25 @@
+{
+	# number of threads
+	# The checkOverlaps = 2 options cause random crash when nthreads is > 1,
+	# possibly due to geometry asked by the run manager to delete objects while in use.
+	# This is an issue open on sci-g until new geant4 versions can be checked.
+	"nthreads": 1,
+
+	# verbosities
+	"verbosity": 1,
+	"gsystemv": 0,
+	"g4systemv": 0,
+
+	# the target system
+	"+gsystem": [
+		{
+			"system":   "./clas12Target",
+			"factory": "text",
+			"variation": "hdice"
+		}
+	],
+
+	"n": 100,
+	"checkOverlaps": 2
+
+}

--- a/projects/clas12/targets/target_longitudinal.jcard
+++ b/projects/clas12/targets/target_longitudinal.jcard
@@ -1,0 +1,25 @@
+{
+	# number of threads
+	# The checkOverlaps = 2 options cause random crash when nthreads is > 1,
+	# possibly due to geometry asked by the run manager to delete objects while in use.
+	# This is an issue open on sci-g until new geant4 versions can be checked.
+	"nthreads": 1,
+
+	# verbosities
+	"verbosity": 1,
+	"gsystemv": 0,
+	"g4systemv": 0,
+
+	# the target system
+	"+gsystem": [
+		{
+			"system":   "./clas12Target",
+			"factory": "text",
+			"variation": "longitudinal"
+		}
+	],
+
+	"n": 100,
+	"checkOverlaps": 2
+
+}

--- a/projects/clas12/targets/target_nd3.jcard
+++ b/projects/clas12/targets/target_nd3.jcard
@@ -1,0 +1,25 @@
+{
+	# number of threads
+	# The checkOverlaps = 2 options cause random crash when nthreads is > 1,
+	# possibly due to geometry asked by the run manager to delete objects while in use.
+	# This is an issue open on sci-g until new geant4 versions can be checked.
+	"nthreads": 1,
+
+	# verbosities
+	"verbosity": 1,
+	"gsystemv": 0,
+	"g4systemv": 0,
+
+	# the target system
+	"+gsystem": [
+		{
+			"system":   "./clas12Target",
+			"factory": "text",
+			"variation": "nd3"
+		}
+	],
+
+	"n": 100,
+	"checkOverlaps": 2
+
+}

--- a/projects/clas12/targets/target_pb208.jcard
+++ b/projects/clas12/targets/target_pb208.jcard
@@ -1,0 +1,25 @@
+{
+	# number of threads
+	# The checkOverlaps = 2 options cause random crash when nthreads is > 1,
+	# possibly due to geometry asked by the run manager to delete objects while in use.
+	# This is an issue open on sci-g until new geant4 versions can be checked.
+	"nthreads": 1,
+
+	# verbosities
+	"verbosity": 1,
+	"gsystemv": 0,
+	"g4systemv": 0,
+
+	# the target system
+	"+gsystem": [
+		{
+			"system":   "./clas12Target",
+			"factory": "text",
+			"variation": "pb208"
+		}
+	],
+
+	"n": 100,
+	"checkOverlaps": 2
+
+}

--- a/projects/clas12/targets/target_pb_test.jcard
+++ b/projects/clas12/targets/target_pb_test.jcard
@@ -1,0 +1,25 @@
+{
+	# number of threads
+	# The checkOverlaps = 2 options cause random crash when nthreads is > 1,
+	# possibly due to geometry asked by the run manager to delete objects while in use.
+	# This is an issue open on sci-g until new geant4 versions can be checked.
+	"nthreads": 1,
+
+	# verbosities
+	"verbosity": 1,
+	"gsystemv": 0,
+	"g4systemv": 0,
+
+	# the target system
+	"+gsystem": [
+		{
+			"system":   "./clas12Target",
+			"factory": "text",
+			"variation": "pb_test"
+		}
+	],
+
+	"n": 100,
+	"checkOverlaps": 2
+
+}

--- a/projects/clas12/targets/target_sn118.jcard
+++ b/projects/clas12/targets/target_sn118.jcard
@@ -1,0 +1,25 @@
+{
+	# number of threads
+	# The checkOverlaps = 2 options cause random crash when nthreads is > 1,
+	# possibly due to geometry asked by the run manager to delete objects while in use.
+	# This is an issue open on sci-g until new geant4 versions can be checked.
+	"nthreads": 1,
+
+	# verbosities
+	"verbosity": 1,
+	"gsystemv": 0,
+	"g4systemv": 0,
+
+	# the target system
+	"+gsystem": [
+		{
+			"system":   "./clas12Target",
+			"factory": "text",
+			"variation": "sn118"
+		}
+	],
+
+	"n": 100,
+	"checkOverlaps": 2
+
+}

--- a/projects/clas12/targets/target_transverse.jcard
+++ b/projects/clas12/targets/target_transverse.jcard
@@ -1,0 +1,25 @@
+{
+	# number of threads
+	# The checkOverlaps = 2 options cause random crash when nthreads is > 1,
+	# possibly due to geometry asked by the run manager to delete objects while in use.
+	# This is an issue open on sci-g until new geant4 versions can be checked.
+	"nthreads": 1,
+
+	# verbosities
+	"verbosity": 1,
+	"gsystemv": 0,
+	"g4systemv": 0,
+
+	# the target system
+	"+gsystem": [
+		{
+			"system":   "./clas12Target",
+			"factory": "text",
+			"variation": "sn118"
+		}
+	],
+
+	"n": 100,
+	"checkOverlaps": 2
+
+}

--- a/projects/clas12/targets/targets.py
+++ b/projects/clas12/targets/targets.py
@@ -5,24 +5,27 @@ import sys, os, argparse
 from gemc_api_utils import *
 from gemc_api_geometry import *
 
-from geometry import VARIATIONBUILDER_MAP 
+from geometry import VARIATION_MAP
+from materials import define_materials 
 
 def main():
     # Provides the -h, --help message
     desc_str = '   Will create the clas12 targets geometry\n'
 
-    # loop over all the defined builder finctions
-    for target_key, builder in VARIATIONBUILDER_MAP.items():
+    # loop over all the defined builder functions
+    for target_key, builder in VARIATION_MAP.items():
         print(f"Building {target_key} target geometry")
         # Define GConfiguration name, factory and description. Initialize it.
         configuration = GConfiguration('clas12Target', 'TEXT', 'CLAS12 Targets')
         configuration.setVariation(target_key)
         configuration.init_geom_file()
+        configuration.init_mats_file()
+        # define materials
+        define_materials(configuration)
         # run the selected builder function
         builder(configuration)
         # print out the GConfiguration
         configuration.printC()
-
 
 if __name__ == '__main__':
     main()

--- a/projects/clas12/targets/targets.py
+++ b/projects/clas12/targets/targets.py
@@ -5,14 +5,14 @@ import sys, os, argparse
 from gemc_api_utils import *
 from gemc_api_geometry import *
 
-from geometry import MAP_TARGET_TO_BUILDER
+from geometry import VARIATIONBUILDER_MAP 
 
 def main():
     # Provides the -h, --help message
     desc_str = '   Will create the clas12 targets geometry\n'
 
     # loop over all the defined builder finctions
-    for target_key, builder in MAP_TARGET_TO_BUILDER.items():
+    for target_key, builder in VARIATIONBUILDER_MAP.items():
         print(f"Building {target_key} target geometry")
         # Define GConfiguration name, factory and description. Initialize it.
         configuration = GConfiguration('clas12Target', 'TEXT', 'CLAS12 Targets')


### PR DESCRIPTION
This PR adds all remaining target geometries and materials to the new Python-based API. The list of targets/variations implemented is:

```py
{
	"lh2": build_geometry_lhydrogen,
	"lh2e": build_geometry_lhydrogen,
	"ld2": build_geometry_lhydrogen,
	"pol_targ": build_geometry_pol_targ,
	"bonus": build_geometry_bonus,
	"pb_test": build_geometry_pb_test,
	"nd3": build_geometry_nd3,

	"c12": build_geometry_c12,
	"sn118" : build_geometry_sn118,
	"pb208" : build_geometry_pb208,
	"cu63" : build_geometry_cu63,
	"al27" : build_geometry_al27,

	"hdice" : build_geometry_hdice,
	"longitudinal" : build_geometry_longitudinal,
	"transverse" : build_geometry_transverse,
	"apollo_nh3": build_geometry_apollo,
	"apollo_nd3": build_geometry_apollo,
}
```

## Review notes

- During the porting process I've left several comments for clarification or confirmation. I'll try to highlight these using the GitHub PR review comment system
- The most relevant of these is about the new `GVolume.makeG4Polycone()`: the order in which the dimensions string is created seems to be different in the Python API with respect to the Perl scripts. I'd like to double-check that this is the intended behavior, since it might affect the generated text file and the way it is loaded in Geant4